### PR TITLE
v2.5.0 update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 = 2.5.0 (August 16, 2021) =
-* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default
+* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default, new filters to quickly unhide categories of hidden blocks
 * [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`. Support for old filter will be removed in a future version
 * [New] Hide Shortcode block since shortcodes work in a Paragraph block
 * [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 = 2.4.0 (January 7, 2021) =
 * [Fix] Hide Embeds which were previously hidden. Refactoring of embeds in WordPress 5.6 broke the previous way of hiding them
+* [Dev] Introduce new `mrw_hidden_embeds` filter. Embeds are no long hidden via the `mrw_hidden_blocks`.
 * [Dev] Improve consistency of how filters are applied
 
 = 2.3.0 (January 3, 2021) =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+= 2.5.0 (August 16, 2021) =
+* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default
+* [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`. Support for old filter will be removed in a future version
+* [New] Hide Shortcode block since shortcodes work in a Paragraph block
+* [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
+* [New] Hide all new Full Site Editing/FSE and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
+* [New] Add new filters `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, and `mrw_hidden_post_blocks` that can be used to unhide entire group of related blocks with `__return_empty_array()`.
+* [Fix] Re-hide `drop-cap` after change in WordPress settings array.
+
 = 2.4.0 (January 7, 2021) =
 * [Fix] Hide Embeds which were previously hidden. Refactoring of embeds in WordPress 5.6 broke the previous way of hiding them
 * [Dev] Introduce new `mrw_hidden_embeds` filter. Embeds are no long hidden via the `mrw_hidden_blocks`.

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -41,6 +41,10 @@ function mrw_block_editor_theme_support() {
 	 */
 	$block_editor_colors_plugin_is_active = in_array( 'block-editor-colors/plugin.php', (array) get_option( 'active_plugins', array() ), true );
 
+	/**
+	 * mrw_block_editor_hide_color_palette filter
+	 * @since 2.0.0
+	 */
 	$hide_palette = apply_filters(
 		'mrw_block_editor_hide_color_palette',
 		empty( $theme_palette )
@@ -68,6 +72,10 @@ function mrw_block_editor_theme_support() {
 	 */
 	$theme_gradients = get_theme_support( 'editor-gradient-presets' );
 
+	/**
+	 * mrw_block_editor_hide_gradient_presets filter
+	 * @since 2.1.0
+	 */
 	$hide_gradients = apply_filters(
 		'mrw_block_editor_hide_gradient_presets',
 		empty( $theme_gradients )
@@ -112,6 +120,10 @@ function mrw_hide_block_directory() {
  */
 function mrw_hidden_blocks() {
 
+	/**
+	 * mrw_hidden_core_blocks filter
+	 * @since 2.5.0
+	 */
 	$hidden_core_blocks = apply_filters( 'mrw_hidden_core_blocks', array(
 		'core/audio',
 		'core/code',
@@ -124,6 +136,10 @@ function mrw_hidden_blocks() {
 		'core/shortcode',
 	) );
 
+	/**
+	 * mrw_hidden_widget_blocks filter
+	 * @since 2.5.0
+	 */
 	$hidden_widgets = apply_filters( 'mrw_hidden_widget_blocks', array(
 		'core/archives',
 		'core/calendar',
@@ -134,6 +150,10 @@ function mrw_hidden_blocks() {
 		'core/categories',
 	) );
 
+	/**
+	 * mrw_hidden_query_blocks filter
+	 * @since 2.5.0
+	 */
 	$hidden_query_blocks = apply_filters( 'mrw_hidden_query_blocks', array(
 		'core/query',
 		'core/query-title',
@@ -146,6 +166,10 @@ function mrw_hidden_blocks() {
 		'core/page-list',
 	) );
 
+	/**
+	 * mrw_hidden_site_blocks filter
+	 * @since 2.5.0
+	 */
 	$hidden_site_blocks = apply_filters( 'mrw_hidden_site_blocks', array(
 		'core/site-logo',
 		'core/site-tagline',
@@ -186,6 +210,10 @@ function mrw_hidden_blocks() {
 		'This filter will stop functioning as soon as January 2022.'
 	);
 
+	/**
+	 * mrw_hidden_blocks filter
+	 * @since 2.3.0
+	 */
 	return apply_filters( 'mrw_hidden_blocks', $hidden_blocks );
 
 }
@@ -194,8 +222,7 @@ function mrw_hidden_blocks() {
  * Return list of hidden embeds
  */
 function mrw_hidden_embeds() {
-	
-	// Embeds
+
 	$hidden_embeds = array(
 		'amazon-kindle',
 		'animoto',
@@ -213,6 +240,10 @@ function mrw_hidden_embeds() {
 		'wordpress-tv',
 	);
 
+	/**
+	 * mrw_hidden_embeds filter
+	 * @since 2.4.0
+	 */
 	return apply_filters( 'mrw_hidden_embeds', $hidden_embeds );
 
 }
@@ -231,6 +262,10 @@ function mrw_jetpack_hidden_blocks() {
 	
 	$jetpack_hidden_block_reason = 'Hidden by MRW Simplified Editor. Use mrw_jetpack_hidden_blocks filter to restore.';
 
+	/**
+	 * mrw_jetpack_hidden_blocks filter
+	 * @since 2.3.0
+	 */
 	$mrw_jetpack_hidden_blocks = apply_filters(
 		'mrw_jetpack_hidden_blocks',
 		array(
@@ -289,6 +324,10 @@ function mrw_hidden_block_styles() {
 		'This filter will stop functioning as soon as January 2022.'
 	);
 
+	/**
+	 * mrw_hidden_block_styles filter
+	 * @since 2.3.0
+	 */
 	return apply_filters( 'mrw_hidden_block_styles', $hidden_styles	);
 
 }
@@ -329,11 +368,19 @@ function mrw_hidden_block_editor_settings() {
 		'This filter will stop functioning as soon as January 2022.'
 	);
 
+	/**
+	 * mrw_hidden_core_blocks filter
+	 * @since 2.3.0
+	 */
 	return apply_filters( 'mrw_hidden_block_editor_settings', $hidden_block_editor_settings );
 
 }
 
-add_filter( 'block_editor_settings_all', 'mrw_block_editor_settings' );
+if( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
+	add_filter( 'block_editor_settings', 'mrw_block_editor_settings' );
+} else {
+	add_filter( 'block_editor_settings_all', 'mrw_block_editor_settings' );
+}
 /**
  * Make changes to editor settings, accounting for plugin filters, via the core block_editor_settings filter
  * 
@@ -347,7 +394,10 @@ function mrw_block_editor_settings( $editor_settings ) {
 	$hidden_settings = mrw_hidden_block_editor_settings();
 
 	if( in_array( 'drop-cap', $hidden_settings ) ) {
+		// WP 5.6+
 		$editor_settings['__experimentalFeatures']['global']['typography']['dropCap'] = false;
+		// WP 5.8+
+		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -112,8 +112,7 @@ function mrw_hide_block_directory() {
  */
 function mrw_hidden_blocks() {
 
-	$hidden_blocks = array(
-		// Core
+	$hidden_core_blocks = apply_filters( 'mrw_hidden_core_blocks', array(
 		'core/audio',
 		'core/code',
 		'core/nextpage',
@@ -122,13 +121,43 @@ function mrw_hidden_blocks() {
 		'core/table',
 		'core/verse',
 		'core/video',
+		'core/shortcode',
+	) );
 
-		// Widgets
-		'core/archive',
+	$hidden_widgets = apply_filters( 'mrw_hidden_widget_blocks', array(
+		'core/archives',
 		'core/calendar',
 		'core/rss',
 		'core/search',
 		'core/tag-cloud',
+		'core/latest-comments',
+		'core/categories',
+	) );
+
+	$hidden_query_blocks = apply_filters( 'mrw_hidden_query_blocks', array(
+		'core/query',
+		'core/query-title',
+		'core/post-title',
+		'core/post-content',
+		'core/post-date',
+		'core/post-excerpt',
+		'core/post-featured-image',
+		'core/post-terms',
+		'core/page-list',
+	) );
+
+	$hidden_site_blocks = apply_filters( 'mrw_hidden_site_blocks', array(
+		'core/site-logo',
+		'core/site-tagline',
+		'core/site-title',
+		'core/loginout',
+	) );
+
+	$hidden_blocks = array_merge(
+		$hidden_core_blocks,
+		$hidden_widgets,
+		$hidden_query_blocks,
+		$hidden_site_blocks,
 	);
 
 	// attempt to detect if More Tag button was previously made available in the classic editor before overriding the More Block
@@ -304,7 +333,7 @@ function mrw_hidden_block_editor_settings() {
 
 }
 
-add_filter( 'block_editor_settings', 'mrw_block_editor_settings' );
+add_filter( 'block_editor_settings_all', 'mrw_block_editor_settings' );
 /**
  * Make changes to editor settings, accounting for plugin filters, via the core block_editor_settings filter
  * 

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -129,11 +129,11 @@ function mrw_hidden_blocks() {
 		'core/code',
 		'core/nextpage',
 		'core/preformatted',
+		'core/shortcode',
 		'core/spacer',
 		'core/table',
 		'core/verse',
 		'core/video',
-		'core/shortcode',
 	) );
 
 	/**
@@ -143,11 +143,11 @@ function mrw_hidden_blocks() {
 	$hidden_widgets = apply_filters( 'mrw_hidden_widget_blocks', array(
 		'core/archives',
 		'core/calendar',
+		'core/categories',
+		'core/latest-comments',
 		'core/rss',
 		'core/search',
 		'core/tag-cloud',
-		'core/latest-comments',
-		'core/categories',
 	) );
 
 	/**
@@ -163,7 +163,6 @@ function mrw_hidden_blocks() {
 		'core/post-excerpt',
 		'core/post-featured-image',
 		'core/post-terms',
-		'core/page-list',
 	) );
 
 	/**
@@ -171,10 +170,11 @@ function mrw_hidden_blocks() {
 	 * @since 2.5.0
 	 */
 	$hidden_site_blocks = apply_filters( 'mrw_hidden_site_blocks', array(
+		'core/loginout',
+		'core/page-list',
 		'core/site-logo',
 		'core/site-tagline',
 		'core/site-title',
-		'core/loginout',
 	) );
 
 	$hidden_blocks = array_merge(

--- a/mrwweb-simple-tinymce.php
+++ b/mrwweb-simple-tinymce.php
@@ -3,7 +3,7 @@
 * Plugin Name: MRW Simplified Editor (formerly MRW Web Design Simple TinyMCE)
 * Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
 * Description: Streamlines the Block Editor and Classic Editor with only the critical features for consistent semantic formatting.
-* Version: 2.4.0
+* Version: 2.5.0
 * Author: Mark Root-Wiley
 * Author URI: https://MRWweb.com
 * Text Domain: mrw-web-design-simple-tinymce

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === MRW Simplified Editor ===
 Contributors: mrwweb
 Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
-Requires at least: 4.1
+Requires at least: 5.8
 Requires PHP: 5.6.20
 Tested up to: 5.6
 Stable tag: 2.4.0
@@ -48,7 +48,7 @@ Due to frequent changes to the block editor, features are only guaranteed for th
 
 = Full List of Hidden Blocks =
 
-**Hidden Core Blocks:** Verse, Table, Preformatted, Code, More, Nextpage, Spacer, Calendar, Tag Cloud, Search, RSS, Audio, Video, Archive
+**Hidden Core Blocks:** Verse, Table, Preformatted, Code, More, Nextpage, Shortcode, Spacer, Calendar, Tag Cloud, Search, RSS, Audio, Video, Archives, Latest Comments, and (New in 5.8) all Site- and Query-related blocks.
 
 **Hidden Core Embeds:** Amazon Kindle, Animoto, Cloudup, Crowd Signal, Daily Motion, Hulu, Mixcloud, Polldaddy, Reverbnation, Smugmug, Speaker, VideoPress, and WordPress.tv
 
@@ -69,6 +69,14 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 2. The "Classic" block of the WordPress 5.0 block editor reflects the impact of this plugin.
 
 == Changelog ==
+
+= 2.5.0 (August , 2021) =
+* Requires WordPress 5.8 for full featureset.
+* [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`.
+* [New] Hide shortcode block since it works in a paragraph block anyway.
+* [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
+* [New] Hide all new Site and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
+* [New] Add new filters `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, and `mrw_hidden_post_blocks` that can be used to unhide entire group of related blocks with `__return_empty_array()`.
 
 = 2.4.0 (January 7, 2021) =
 * [Fix] Hide Embeds which were previously hidden. Refactoring of embeds in WordPress 5.6 broke the previous way of hiding them

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 * [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
 * [New] Hide all new Site and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
 * [New] Add new filters `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, and `mrw_hidden_post_blocks` that can be used to unhide entire group of related blocks with `__return_empty_array()`.
+* [Fix] Rehide `drop-cap` after change in WordPress settings array.
 
 = 2.4.0 (January 7, 2021) =
 * [Fix] Hide Embeds which were previously hidden. Refactoring of embeds in WordPress 5.6 broke the previous way of hiding them

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Help your CMS editors create semantic content and style it with the theme for co
 
 This plugin greatly simplifies the block editor by **hiding** all of the following features. Filters are provided for developers to adjust what is hidden (including making it easier to hide blocks).
 
-- **Infrequently Used Core Blocks:** Verse, Table, Audio, Video, Code, More, Nextpage, Spacer, *and more*. See [FAQ for full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
+- **Infrequently Used Core Blocks** such as Verse, Table, Audio, Video, etc., and all Query- and Site-related blocks. See [FAQ for full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
 - **Block Styles and the "Default style" feature**
 - **Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, image percentage and pixel sizing, font sizing by pixel, open links in new tabs (mostly hidden)
 - **Default Color & gradient settings** (Custom theme palettes/settings are never hidden)
@@ -48,11 +48,21 @@ Due to frequent changes to the block editor, features are only guaranteed for th
 
 = Full List of Hidden Blocks =
 
-**Hidden Core Blocks:** Verse, Table, Preformatted, Code, More, Nextpage, Shortcode, Spacer, Calendar, Tag Cloud, Search, RSS, Audio, Video, Archives, Latest Comments, and (New in 5.8) all Site- and Query-related blocks.
+**Hidden Core Blocks:**
 
-**Hidden Core Embeds:** Amazon Kindle, Animoto, Cloudup, Crowd Signal, Daily Motion, Hulu, Mixcloud, Polldaddy, Reverbnation, Smugmug, Speaker, VideoPress, and WordPress.tv
+- **Text & Media Blocks:** Audio, Code, Next Page, Preformatted, Shortcode, Spacer, Table, Verse, Video
+- **Widget Blocks:** Archives, Calendar, Categories, Latest Comments, RSS, Search, Tag Cloud
+- **Query-Related Blocks**: Query, Archive Title (Query Title), Post Title, Post Content, Post Date, Post Excerpt, Post Featured Image, Post Tags & Categories (Post Terms)
+Page List
+- **FSE Blocks:** Login/Out, Page List, Site Logo, Site Tagline, Site Title
 
-**Hidden Jetpack Blocks:** Markdown, Star Rating, Repeat Visitor, OpenTable, Revue, Eventbrite Tickets, GIF, Calendly, and WhatsApp Button
+**Hidden Core Embeds:**
+
+- Amazon Kindle, Animoto, Cloudup, Crowd Signal, Daily Motion, Hulu, Mixcloud, Polldaddy, Reverbnation, Smugmug, Speaker, VideoPress, and WordPress.tv
+
+**Hidden Jetpack Blocks:**
+
+- Markdown, Star Rating, Repeat Visitor, OpenTable, Revue, Eventbrite Tickets, GIF, Calendly, and WhatsApp Button
 
 = Plugin Filters =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === MRW Simplified Editor ===
 Contributors: mrwweb
 Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
-Requires at least: 5.8
+Requires at least: 4.1
 Requires PHP: 5.6.20
 Tested up to: 5.6
 Stable tag: 2.5.0
@@ -13,7 +13,7 @@ Focus editors on making great content and letting their themes make it beautiful
 
 == Description ==
 
-Help your CMS editors create semantic content and style it with the theme for consistent formatting and portable content. This plugin removes blocks and other styling options to help editors focus.
+Help your site's editors create semantic content and style it with the theme for consistent formatting and portable content. This plugin removes blocks and other styling options to help editors focus.
 
 > I built this plugin for use on client sites. I hope you'll find it useful! **This is an opinionated plugin.** Read an in-depth reasoning behind the decisions made by this plugin in the post ["A WordPress Formatting Manifesto."](http://mrwweb.com/wordpress-formatting-manifesto/) If you find it compelling, then you'll probably like this plugin!
 
@@ -21,11 +21,11 @@ Help your CMS editors create semantic content and style it with the theme for co
 
 = Block Editor Features =
 
-This plugin greatly simplifies the block editor by **hiding** all of the following features. Filters are provided for developers to adjust what is hidden (including making it easier to hide blocks).
+This plugin greatly simplifies the block editor by **hiding** all of the following features. Filters are provided for developers to adjust what is hidden (including making it easier to hide additional blocks).
 
 - **Infrequently Used Core Blocks** such as Verse, Table, Audio, Video, etc., and all Query- and Site-related blocks. See [FAQ for full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
-- **Block Styles and the "Default style" feature**
-- **Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, image percentage and pixel sizing, font sizing by pixel, open links in new tabs (mostly hidden)
+- **All Core Block Styles and the "Default style" feature**
+- **Some Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, image percentage and pixel sizing, font sizing by pixel, open links in new tabs (mostly hidden)
 - **Default Color & gradient settings** (Custom theme palettes/settings are never hidden)
 - **Block Patterns (WP 5.5+)**
 - **Block Directory (WP 5.5+)**
@@ -34,8 +34,8 @@ This plugin greatly simplifies the block editor by **hiding** all of the followi
 
 The plugin also improves the editor by:
 
-- **Increase prominence of contrast errors**
-- **Styles "Save draft" as a button**
+- **Increasing prominence of contrast errors**
+- **Styling "Save draft" as a button**
 
 = Classic Editor / Classic Block Features =
 
@@ -76,12 +76,12 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 
 1. The Block Editor simplified, here with no colors or drop caps for the Paragraph block.
 
-2. The "Classic" block of the WordPress 5.0 block editor reflects the impact of this plugin in the Classic Editor.
+2. The "Classic" block of the WordPress block editor also reflects the impact of this plugin in the Classic Editor.
 
 == Changelog ==
 
 = 2.5.0 (August 16, 2021) =
-* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default
+* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default, new filters to quickly unhide categories of hidden blocks
 * [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`. Support for old filter will be removed in a future version
 * [New] Hide Shortcode block since shortcodes work in a Paragraph block
 * [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
@@ -111,4 +111,4 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 
 == Upgrade Notice ==
 = 2.5.0 =
-* WordPress 5.8 support and fixes, more hidden blocks by default
+* WordPress 5.8 support and fixes, more hidden blocks by default, new filters to quickly unhide categories of hidden blocks

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
 Requires at least: 5.8
 Requires PHP: 5.6.20
 Tested up to: 5.6
-Stable tag: 2.4.0
+Stable tag: 2.5.0
 Donate link: https://www.paypal.me/rootwiley
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -15,7 +15,7 @@ Focus editors on making great content and letting their themes make it beautiful
 
 Help your CMS editors create semantic content and style it with the theme for consistent formatting and portable content. This plugin removes blocks and other styling options to help editors focus.
 
-> I built this plugin for use on client sites. I hopes you'll find it useful! **This is an opinionated plugin.** Read an in-depth reasoning behind the decisions made by this plugin in the post ["A WordPress Formatting Manifesto."](http://mrwweb.com/wordpress-formatting-manifesto/)
+> I built this plugin for use on client sites. I hope you'll find it useful! **This is an opinionated plugin.** Read an in-depth reasoning behind the decisions made by this plugin in the post ["A WordPress Formatting Manifesto."](http://mrwweb.com/wordpress-formatting-manifesto/) If you find it compelling, then you'll probably like this plugin!
 
 [Contribute on Github.](https://github.com/mrwweb/mrw-simplified-editor-wordpress/)
 
@@ -39,7 +39,7 @@ The plugin also improves the editor by:
 
 = Classic Editor / Classic Block Features =
 
-Reduce editor to a single row of buttons: "Styleselect" (Headings 2-4 and Blockquote as well as Strikethrough, Subscript, Superscript, Preformatted, and Code), Bold, Italic, Add/Edit Link, Break Link, Horizontal Rule (added 1.2.0), Paste as Plain Text, Remove Styles, Special Characters, Undo, Redo, Help, Distraction Free Mode.
+Reduces editor to a single row of buttons: "Styleselect" (Headings 2-4 and Blockquote as well as Strikethrough, Subscript, Superscript, Preformatted, and Code), Bold, Italic, Add/Edit Link, Break Link, Horizontal Rule, Paste as Plain Text, Remove Styles, Special Characters, Undo, Redo, Help, Distraction Free Mode.
 
 = Note on WordPress version Support =
 Due to frequent changes to the block editor, features are only guaranteed for the latest version of WordPress.
@@ -76,18 +76,18 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 
 1. The Block Editor simplified, here with no colors or drop caps for the Paragraph block.
 
-2. The "Classic" block of the WordPress 5.0 block editor reflects the impact of this plugin.
+2. The "Classic" block of the WordPress 5.0 block editor reflects the impact of this plugin in the Classic Editor.
 
 == Changelog ==
 
-= 2.5.0 (August , 2021) =
-* Requires WordPress 5.8 for full featureset.
-* [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`.
-* [New] Hide shortcode block since it works in a paragraph block anyway.
+= 2.5.0 (August 16, 2021) =
+* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default
+* [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`. Support for old filter will be removed in a future version
+* [New] Hide Shortcode block since shortcodes work in a Paragraph block
 * [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
-* [New] Hide all new Site and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
+* [New] Hide all new Full Site Editing/FSE and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
 * [New] Add new filters `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, and `mrw_hidden_post_blocks` that can be used to unhide entire group of related blocks with `__return_empty_array()`.
-* [Fix] Rehide `drop-cap` after change in WordPress settings array.
+* [Fix] Re-hide `drop-cap` after change in WordPress settings array.
 
 = 2.4.0 (January 7, 2021) =
 * [Fix] Hide Embeds which were previously hidden. Refactoring of embeds in WordPress 5.6 broke the previous way of hiding them
@@ -110,5 +110,5 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 * [Changelog on Github](https://github.com/mrwweb/mrw-simplified-editor-wordpress/blob/master/changelog.txt)
 
 == Upgrade Notice ==
-= 2.4.0 =
-* Fix hiding of embeds which broke in WordPress 5.6
+= 2.5.0 =
+* WordPress 5.8 support and fixes, more hidden blocks by default


### PR DESCRIPTION
* tl;dr - WordPress 5.8 support and fixes, more hidden blocks by default, new filters to quickly unhide categories of hidden blocks
* [Fix] Use updated `block_editor_settings_all` filter instead of deprecated `block_editor_settings`. Support for old filter will be removed in a future version
* [New] Hide Shortcode block since shortcodes work in a Paragraph block
* [New] Hide Archives, Categories, and Latest Comments widget blocks by default after almost never using these
* [New] Hide all new Full Site Editing/FSE and Query-related blocks (e.g. Query Loop, Post Title, Site Logo, etc.)
* [New] Add new filters `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, and `mrw_hidden_post_blocks` that can be used to unhide entire group of related blocks with `__return_empty_array()`.
* [Fix] Re-hide `drop-cap` after change in WordPress settings array.