### PR TITLE
Features/block editor settings all filter

### DIFF
--- a/css/block-editor.css
+++ b/css/block-editor.css
@@ -4,16 +4,10 @@
  * You can use the `mrw_disabled_block_editor_settings` filter to turn change which settings are disables in a backwards-compatible way
  */
 
-/* Dropcap */
-/* WP 5.0-5.3 */
-.mrw-block-editor-no-drop-cap .components-panel__body.blocks-font-size .components-toggle-control:nth-child(3),
-/* WP 5.4+ */
-.mrw-block-editor-no-drop-cap .components-font-size-picker + .components-toggle-control
-/* WP 5.5 😭 */ {
-	display: none;
-}
-
-/* Don't Open Links in New Tabs */
+/*
+ Don't Open Links in New Tabs
+ Filter Value: new-tabs
+ */
 .mrw-block-editor-no-new-tabs .components-popover__content .block-editor-link-control .block-editor-link-control__settings,
 .mrw-block-editor-no-new-tabs .block-editor-url-popover__settings .components-toggle-control {
 	display: none;
@@ -22,6 +16,7 @@
 /*
  Hide the "Upload" button in the editor because it skips the media library
  Hide the "Image from URL" option to discourage hotlinking and not having alt text
+ Filter Value: image-file-upload
  */
 .mrw-block-editor-no-image-file-upload .components-form-file-upload,
 .mrw-block-editor-no-image-url .editor-media-placeholder__url-input-container,
@@ -31,7 +26,10 @@
 	display: none;
 }
 
-/* Hide Heading Levels 1, 5, and 6 */
+/*
+ Hide Heading Levels 1, 5, and 6
+ Options: heading-1, heading-5, heading-6
+ */
 .mrw-block-editor-no-heading-1 .components-button[data-subscript="1"],
 .mrw-block-editor-no-heading-5 .components-button[data-subscript="5"],
 .mrw-block-editor-no-heading-6 .components-button[data-subscript="6"],
@@ -46,13 +44,19 @@
 	display: none;
 }
 
-/* Image Pixel & Percentage Sizing  */
+/* 
+ Image Pixel & Percentage Sizing
+ Filter Value: image-dimensions
+ */
 .mrw-block-editor-no-image-dimensions .block-library-image__dimensions,
 .mrw-block-editor-no-image-dimensions .block-editor-image-size-control {
 	display: none;
 }
 
-/* Hide "Default style" select for style variations */
+/* 
+ Hide "Default style" select for style variations
+ Filter Value: default-style-variation
+ */
 .mrw-block-editor-no-default-style-variation .block-editor-block-styles + .components-base-control {
 	display: none;
 }

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -340,16 +340,17 @@ function mrw_hidden_block_styles() {
 function mrw_hidden_block_editor_settings() {
 
 	$hidden_block_editor_settings = array(
+		'block-directory',
+		'border-radius',
+		'default-style-variation',
 		'drop-cap',
-		'image-file-upload',
-		'image-url',
 		'heading-1',
 		'heading-5',
 		'heading-6',
 		'image-dimensions',
+		'image-file-upload',
+		'image-url',
 		'new-tabs',
-		'block-directory',
-		'default-style-variation'
 	);
 
 	$hidden_block_editor_settings = apply_filters_deprecated(
@@ -379,7 +380,7 @@ function mrw_hidden_block_editor_settings() {
 if( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
 	add_filter( 'block_editor_settings', 'mrw_block_editor_settings' );
 } else {
-	add_filter( 'block_editor_settings_all', 'mrw_block_editor_settings' );
+	add_filter( 'block_editor_settings_all', 'mrw_block_editor_settings', 10, 2 );
 }
 /**
  * Make changes to editor settings, accounting for plugin filters, via the core block_editor_settings filter
@@ -389,7 +390,7 @@ if( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
  *
  * @see https://github.com/joppuyo/remove-drop-cap/blob/v1.1.0/remove-drop-cap.php#L22
  */
-function mrw_block_editor_settings( $editor_settings ) {
+function mrw_block_editor_settings( $editor_settings, $context ) {
 
 	$hidden_settings = mrw_hidden_block_editor_settings();
 
@@ -398,6 +399,10 @@ function mrw_block_editor_settings( $editor_settings ) {
 		$editor_settings['__experimentalFeatures']['global']['typography']['dropCap'] = false;
 		// WP 5.8+
 		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
+	}
+
+	if( in_array( 'border-radius', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['customRadius'] = false;	
 	}
 
 	return $editor_settings;


### PR DESCRIPTION
- Hide button border radius by default! Disable by removing the `border-radius` value from the array in the `mrw_hidden_block_editor_settings` filter.
- Remove old CSS method for hiding dropCap
- Improve documentation of options to toggle CSS feature hiding