### PR TITLE
Features/hide new 5 9 settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 2.8.0 (February 21, 2022) =
+* [New] Hide many new default block controls added in WordPress 5.9. All options can be enabled with the [mrw_hidden_block_editor_settings filter](https://github.com/mrwweb/mrw-simplified-editor-wordpress/wiki/Filter-Reference).
+	* Text Formatting: line-height, font-weight, letter-spacing, and text-transform
+	* Spacing: gap, margin, padding
+	* Borders: General, pull-quote
+* [Remove] Remove support for hiding paragraph block dropcap setting in WordPress 5.6 and earlier
+* [Remove] Remove support for all old versions of `mrw_*` filters using the terms "blacklist" and "disabled"
+
 = 2.7.0 (February 4, 2022) =
 * [New] Hide new blocks added in WordPress 5.9: Navigation, Post Pagination, Post Author, Post Comments, Term Description, Wolfram Cloud Embed
 * [Dev] Improve inline documentation of new `mrw_hidden_*_blocks` filters added in Simplified Editor 2.5.0

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -376,6 +376,7 @@ function mrw_hidden_block_editor_settings() {
 		'new-tabs',
 		'padding',
 		'pullquote-border',
+		'spacing',
 		'text-transform',
 	);
 
@@ -468,6 +469,11 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 	/* Border Pullquote */
 	if( in_array( 'pullquote-border', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['blocks']['core/pullquote']['border'] = [];
+	}
+
+	/* Gap and Margin */
+	if( in_array( 'spacing', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['spacing'] = [];
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -362,14 +362,18 @@ function mrw_hidden_block_editor_settings() {
 		'border-radius',
 		'default-style-variation',
 		'drop-cap',
+		'font-weight',
+		'font-style',
 		'heading-1',
 		'heading-5',
 		'heading-6',
 		'image-dimensions',
 		'image-file-upload',
 		'image-url',
-		'new-tabs',
+		'letter-spacing',
 		'line-height',
+		'new-tabs',
+		'text-transform',
 	);
 
 	$hidden_block_editor_settings = apply_filters_deprecated(
@@ -426,6 +430,26 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 	/* Line Height */
 	if( in_array( 'line-height', $hidden_settings) ) {
 		$editor_settings['enableCustomLineHeight'] = false;
+	}
+
+	/* Letter Spacing */
+	if( in_array( 'letter-spacing', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['letterSpacing'] = false;
+	}
+
+	/* Text Transform */
+	if( in_array( 'text-transform', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['textTransform'] = false;
+	}
+
+	/* Font Weight */
+	if( in_array( 'text-transform', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['fontWeight'] = false;
+	}
+
+	/* Font Style */
+	if( in_array( 'text-transform', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -373,6 +373,7 @@ function mrw_hidden_block_editor_settings() {
 		'letter-spacing',
 		'line-height',
 		'new-tabs',
+		'padding',
 		'text-transform',
 	);
 
@@ -443,13 +444,17 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 	}
 
 	/* Font Weight */
-	if( in_array( 'text-transform', $hidden_settings) ) {
+	if( in_array( 'font-weight', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontWeight'] = false;
 	}
 
 	/* Font Style */
-	if( in_array( 'text-transform', $hidden_settings) ) {
+	if( in_array( 'font-style', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
+	}
+
+	if( in_array( 'padding', $hidden_settings) ) {
+		$editor_settings['enableCustomSpacing'] = false;
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -413,18 +413,17 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 
 	$hidden_settings = mrw_hidden_block_editor_settings();
 
+	/* Drop Cap */
 	if( in_array( 'drop-cap', $hidden_settings ) ) {
-		if( is_wp_version_compatible( '5.8' ) ) {
-			$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
-		} elseif( is_wp_version_compatible( '5.6' ) ) {
-			$editor_settings['__experimentalFeatures']['global']['typography']['dropCap'] = false;
-		}
+		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
 	}
 
+	/* Button Border Radius */
 	if( in_array( 'border-radius', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['customRadius'] = false;	
 	}
 
+	/* Line Height */
 	if( in_array( 'line-height', $hidden_settings) ) {
 		$editor_settings['enableCustomLineHeight'] = false;
 	}

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -359,6 +359,7 @@ function mrw_hidden_block_editor_settings() {
 
 	$hidden_block_editor_settings = array(
 		'block-directory',
+		'border',
 		'border-radius',
 		'default-style-variation',
 		'drop-cap',
@@ -374,6 +375,7 @@ function mrw_hidden_block_editor_settings() {
 		'line-height',
 		'new-tabs',
 		'padding',
+		'pullquote-border',
 		'text-transform',
 	);
 
@@ -453,8 +455,19 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
 	}
 
+	/* Padding */
 	if( in_array( 'padding', $hidden_settings) ) {
 		$editor_settings['enableCustomSpacing'] = false;
+	}
+
+	/* Border */
+	if( in_array( 'border', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['border'] = [];
+	}
+
+	/* Border Pullquote */
+	if( in_array( 'pullquote-border', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['blocks']['core/pullquote']['border'] = [];
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -211,22 +211,6 @@ function mrw_hidden_blocks() {
 		$hidden_blocks[] = 'core/more';
 	}
 
-	$hidden_blocks = apply_filters_deprecated(
-		'mrw_block_blacklist',
-		array( $hidden_blocks ),
-		'2.2.0 of MRW Simplified Editor',
-		'mrw_hidden_blocks',
-		'This filter will stop functioning as soon as August 2021.'
-	);
-
-	$hidden_blocks = apply_filters_deprecated(
-		'mrw_disabled_blocks',
-		array( $hidden_blocks ),
-		'2.3.0 of MRW Simplified Editor',
-		'mrw_hidden_blocks',
-		'This filter will stop functioning as soon as January 2022.'
-	);
-
 	/**
 	 * mrw_hidden_blocks filter
 	 * @since 2.3.0
@@ -326,22 +310,6 @@ function mrw_hidden_block_styles() {
 		'core/social-links'	=> array( 'default', 'logos-only', 'pill-shape' ),
 	);
 
-	$hidden_styles = apply_filters_deprecated(
-		'mrw_style_variations_blacklist',
-		array( $hidden_styles ),
-		'2.2.0 of MRW Simplified Editor',
-		'mrw_hidden_block_styles',
-		'This filter will stop functioning as soon as August 2021.'
-	);
-
-	$hidden_styles = apply_filters_deprecated(
-		'mrw_disabled_style_variations',
-		array( $hidden_styles ),
-		'2.3.0 of MRW Simplified Editor',
-		'mrw_hidden_block_styles',
-		'This filter will stop functioning as soon as January 2022.'
-	);
-
 	/**
 	 * mrw_hidden_block_styles filter
 	 * @since 2.3.0
@@ -378,22 +346,6 @@ function mrw_hidden_block_editor_settings() {
 		'pullquote-border',
 		'spacing',
 		'text-transform',
-	);
-
-	$hidden_block_editor_settings = apply_filters_deprecated(
-		'mrw_block_editor_disable_settings',
-		array( $hidden_block_editor_settings ),
-		'2.2.0 of MRW Simplified Editor',
-		'mrw_hidden_block_editor_settings',
-		'This filter will stop functioning as soon as August 2021.'
-	);
-
-	$hidden_block_editor_settings = apply_filters_deprecated(
-		'mrw_disabled_block_editor_settings',
-		array( $hidden_block_editor_settings ),
-		'2.3.0 of MRW Simplified Editor',
-		'mrw_hidden_block_editor_settings',
-		'This filter will stop functioning as soon as January 2022.'
 	);
 
 	/**

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -268,7 +268,7 @@ function mrw_hidden_embeds() {
 
 add_action( 'jetpack_register_gutenberg_extensions', 'mrw_jetpack_hidden_blocks', 99 );
 /**
- * Hiden Jetpack Blocks
+ * Hidden Jetpack Blocks
  *
  * @see  https://developer.jetpack.com/hooks/jetpack_register_gutenberg_extensions/
  */

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -369,6 +369,7 @@ function mrw_hidden_block_editor_settings() {
 		'image-file-upload',
 		'image-url',
 		'new-tabs',
+		'line-height',
 	);
 
 	$hidden_block_editor_settings = apply_filters_deprecated(
@@ -422,6 +423,10 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 
 	if( in_array( 'border-radius', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['customRadius'] = false;	
+	}
+
+	if( in_array( 'line-height', $hidden_settings) ) {
+		$editor_settings['enableCustomLineHeight'] = false;
 	}
 
 	return $editor_settings;

--- a/mrwweb-simple-tinymce.php
+++ b/mrwweb-simple-tinymce.php
@@ -3,7 +3,7 @@
 * Plugin Name: MRW Simplified Editor (formerly MRW Web Design Simple TinyMCE)
 * Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
 * Description: Streamlines the Block Editor and Classic Editor with only the critical features for consistent semantic formatting.
-* Version: 2.7.0
+* Version: 2.8.0
 * Author: Mark Root-Wiley
 * Author URI: https://MRWweb.com
 * Text Domain: mrw-web-design-simple-tinymce

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
 Requires at least: 5.2
 Requires PHP: 5.6.20
 Tested up to: 5.9
-Stable tag: 2.7.0
+Stable tag: 2.8.0
 Donate link: https://www.paypal.me/rootwiley
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -79,6 +79,14 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 2. The "Classic" block of the WordPress block editor also reflects the impact of this plugin in the Classic Editor.
 
 == Changelog ==
+
+= 2.8.0 (February 21, 2022) =
+* [New] Hide many new default block controls added in WordPress 5.9. All options can be enabled with the [mrw_hidden_block_editor_settings filter](https://github.com/mrwweb/mrw-simplified-editor-wordpress/wiki/Filter-Reference).
+	* Text Formatting: line-height, font-weight, letter-spacing, and text-transform
+	* Spacing: gap, margin, padding
+	* Borders: General, pull-quote
+* [Remove] Remove support for hiding paragraph block dropcap setting in WordPress 5.6 and earlier
+* [Remove] Remove support for all old versions of `mrw_*` filters using the terms "blacklist" and "disabled"
 
 = 2.7.0 (February 4, 2022) =
 * [New] Hide new blocks added in WordPress 5.9: Navigation, Post Pagination, Post Author, Post Comments, Term Description, Wolfram Cloud Embed


### PR DESCRIPTION
= 2.8.0 (February 21, 2022) =
* [New] Hide many new default block controls added in WordPress 5.9. All options can be enabled with the [mrw_hidden_block_editor_settings filter](https://github.com/mrwweb/mrw-simplified-editor-wordpress/wiki/Filter-Reference).
	* Text Formatting: line-height, font-weight, letter-spacing, and text-transform
	* Spacing: gap, margin, padding
	* Borders: General, pull-quote
* [Remove] Remove support for hiding paragraph block dropcap setting in WordPress 5.6 and earlier
* [Remove] Remove support for all old versions of `mrw_*` filters using the terms "blacklist" and "disabled"