### PR TITLE
WP 6.1 compat, v2.10.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 2.10.0 (October 15, 2022) =
+- Tested up to WordPress 6.1
+- Hide new Text Decoration settings by default (enable via `text-decoration` in  `mrw_hidden_block_editor_settings`)
+- Hide image duotone setting (enable via `duotone` in `mrw_hidden_block_editor_settings`)
+
 = 2.9.0 (May 27, 2022) =
 - WordPress 6.0 compatibility fixes: hide new blocks, fix regressions
 - [New] Hide the default color palette which was re-added by default in WP 5.8. Can be shown by removing `default-color-palette` value from `mrw_hidden_block_editor_settings` filter

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -337,6 +337,7 @@ function mrw_hidden_block_editor_settings() {
 		'default-color-palette',
 		'default-style-variation',
 		'drop-cap',
+		'duotone',
 		'font-weight',
 		'font-style',
 		'heading-1',
@@ -401,6 +402,12 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 	/* Drop Cap */
 	if( in_array( 'drop-cap', $hidden_settings ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
+	}
+
+	/* Duotone */
+	if( in_array( 'duotone', $hidden_settings ) ) {
+		$editor_settings['__experimentalFeatures']['color']['duotone'] = null;
+		$editor_settings['__experimentalFeatures']['color']['customDuotone'] = false;
 	}
 
 	/* Font Style */

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -380,6 +380,19 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 
 	$hidden_settings = mrw_hidden_block_editor_settings();
 
+	/* Border */
+	if( in_array( 'border', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['border'] = [];
+	}
+
+	/* Border Radius, Button */
+	if( in_array( 'border-radius', $hidden_settings) ) {
+		/* WordPress < 6.0 */
+		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['customRadius'] = false;
+		/* WordPress 6.0+ */
+		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['radius'] = false;	
+	}
+
 	/* Default Color Pallete */
 	if( in_array( 'default-color-palette', $hidden_settings ) ) {
 		$editor_settings['__experimentalFeatures']['color']['defaultPalette'] = false;
@@ -390,32 +403,9 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
 	}
 
-	/* Button Border Radius */
-	if( in_array( 'border-radius', $hidden_settings) ) {
-		/* WordPress < 6.0 */
-		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['customRadius'] = false;
-		/* WordPress 6.0+ */
-		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['radius'] = false;	
-	}
-
-	/* Line Height */
-	if( in_array( 'line-height', $hidden_settings) ) {
-		$editor_settings['enableCustomLineHeight'] = false;
-	}
-
-	/* Letter Spacing */
-	if( in_array( 'letter-spacing', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['typography']['letterSpacing'] = false;
-	}
-
-	/* Text Transform */
-	if( in_array( 'text-transform', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['typography']['textTransform'] = false;
-	}
-
-	/* Text Decoration */
-	if( in_array( 'text-decoration', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['typography']['textDecoration'] = false;
+	/* Font Style */
+	if( in_array( 'font-style', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
 	}
 
 	/* Font Weight */
@@ -423,9 +413,19 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontWeight'] = false;
 	}
 
-	/* Font Style */
-	if( in_array( 'font-style', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
+	/* Gap and Margin */
+	if( in_array( 'spacing', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['spacing'] = [];
+	}
+
+	/* Letter Spacing */
+	if( in_array( 'letter-spacing', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['letterSpacing'] = false;
+	}
+
+	/* Line Height */
+	if( in_array( 'line-height', $hidden_settings) ) {
+		$editor_settings['enableCustomLineHeight'] = false;
 	}
 
 	/* Padding */
@@ -433,19 +433,19 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 		$editor_settings['enableCustomSpacing'] = false;
 	}
 
-	/* Border */
-	if( in_array( 'border', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['border'] = [];
-	}
-
-	/* Border Pullquote */
+	/* Pullquote Border */
 	if( in_array( 'pullquote-border', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['blocks']['core/pullquote']['border'] = [];
 	}
 
-	/* Gap and Margin */
-	if( in_array( 'spacing', $hidden_settings) ) {
-		$editor_settings['__experimentalFeatures']['spacing'] = [];
+	/* Text Decoration */
+	if( in_array( 'text-decoration', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['textDecoration'] = false;
+	}
+
+	/* Text Transform */
+	if( in_array( 'text-transform', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['textTransform'] = false;
 	}
 
 	return $editor_settings;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -351,6 +351,7 @@ function mrw_hidden_block_editor_settings() {
 		'padding',
 		'pullquote-border',
 		'spacing',
+		'text-decoration',
 		'text-transform',
 	);
 
@@ -410,6 +411,11 @@ function mrw_block_editor_settings( $editor_settings, $context ) {
 	/* Text Transform */
 	if( in_array( 'text-transform', $hidden_settings) ) {
 		$editor_settings['__experimentalFeatures']['typography']['textTransform'] = false;
+	}
+
+	/* Text Decoration */
+	if( in_array( 'text-decoration', $hidden_settings) ) {
+		$editor_settings['__experimentalFeatures']['typography']['textDecoration'] = false;
 	}
 
 	/* Font Weight */

--- a/mrwweb-simple-tinymce.php
+++ b/mrwweb-simple-tinymce.php
@@ -3,7 +3,7 @@
 * Plugin Name: MRW Simplified Editor (formerly MRW Web Design Simple TinyMCE)
 * Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
 * Description: Streamlines the Block Editor and Classic Editor with only the critical features for consistent semantic formatting.
-* Version: 2.9.0
+* Version: 2.10.0
 * Author: Mark Root-Wiley
 * Author URI: https://MRWweb.com
 * Text Domain: mrw-web-design-simple-tinymce

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: mrwweb
 Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
 Requires at least: 5.2
 Requires PHP: 5.6.20
-Tested up to: 6.0
-Stable tag: 2.9.0
+Tested up to: 6.1
+Stable tag: 2.10.0
 Donate link: https://www.paypal.me/rootwiley
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -25,7 +25,7 @@ This plugin greatly simplifies the block editor by **hiding** all of the followi
 
 - **Infrequently Used Core Blocks** such as Verse, Table, Audio, Video, etc., and all Query- and Site-related blocks. See FAQ for [full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
 - **All Core Block Styles and the "Default style" feature**
-- **Some Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, image percentage and pixel sizing, font sizing by pixel, open links in new tabs (mostly hidden)
+- **Some Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, image percentage and pixel sizing, font sizing by pixel, open links in new tabs (mostly hidden), duotone, text styles like line-height and letter spacing, etc.
 - **Default Color & gradient settings** (Custom theme palettes/settings are never hidden)
 - **Core Block Patterns (WP 5.5+)**
 - **Block Directory (WP 5.5+)**
@@ -79,6 +79,11 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 2. The "Classic" block of the WordPress block editor also reflects the impact of this plugin in the Classic Editor.
 
 == Changelog ==
+= 2.10.0 (October 15, 2022) =
+- Tested up to WordPress 6.1
+- Hide new Text Decoration settings by default (enable via `text-decoration` in  `mrw_hidden_block_editor_settings`)
+- Hide image duotone setting (enable via `duotone` in `mrw_hidden_block_editor_settings`)
+
 = 2.9.0 (May 27, 2022) =
 - WordPress 6.0 compatibility fixes: hide new blocks, fix regressions
 - [New] Hide the default color palette which was re-added by default in WP 5.8. Can be shown by removing `default-color-palette` value from `mrw_hidden_block_editor_settings` filter


### PR DESCRIPTION
- Tested up to WordPress 6.1
- Hide new Text Decoration settings by default (enable via `text-decoration` in  `mrw_hidden_block_editor_settings`)
- Hide image duotone setting (enable via `duotone` in `mrw_hidden_block_editor_settings`)