### PR TITLE
add blueprint.json to support plugin playground on wordpress.org plugin repository

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "landingPage": "\/wp-admin\/post-new.php",
+    "steps": [
+        {
+            "step": "login",
+            "username": "admin",
+            "password": "password"
+        },
+        {
+            "step": "installPlugin",
+            "pluginZipFile": {
+                "resource": "wordpress.org\/plugins",
+                "slug": "mrw-web-design-simple-tinymce"
+            },
+            "options": {
+                "activate": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Closes #77 