### PR TITLE
Merge version 2.15.0 with compat for WordPress 7.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Plugin Does
+
+MRW Simplified Editor is a WordPress plugin that streamlines the block editor (Gutenberg) and classic editor (TinyMCE) to help content editors focus on semantic content rather than visual styling. It hides blocks, block styles, and editor settings that lead to inconsistent formatting. All hidden items can be re-enabled via PHP filters.
+
+## Code Architecture
+
+The plugin has no build step — all PHP, JS, and CSS are hand-authored and loaded directly.
+
+### Entry Point
+
+`mrwweb-simple-tinymce.php` — defines `MRW_SIMPLIFIED_EDITOR_VERSION` and requires the two includes.
+
+### PHP (`inc/`)
+
+Both files use the `MRW\SimplifiedEditor` namespace.
+
+- `inc/block-editor.php` — All Gutenberg modifications. Key functions:
+  - `hidden_blocks()` — returns filterable list of blocks hidden from the inserter (blocks are hidden, not unregistered, to avoid editor crashes on existing content)
+  - `hidden_embeds()`, `hidden_social_links()`, `hidden_block_styles()`, `hidden_block_editor_settings()` — each returns a filterable array used by both PHP and JS
+  - `block_editor_settings()` — hooked to `block_editor_settings_all`, modifies `__experimentalFeatures` directly
+  - `block_editor_js_config()` — collects all hidden-item arrays and localizes them as `mrwEditorOptions` for JS
+  - `block_editor_assets()` — enqueues `css/block-editor.css` and `js/block-editor.js` on `enqueue_block_editor_assets`
+  - `block_editor_settings_admin_classes()` — adds `mrw-block-editor-no-{setting}` body classes for CSS targeting
+
+- `inc/classic-editor.php` — TinyMCE modifications via `mce_buttons` and `tiny_mce_before_init` filters. Reduces toolbar to a single row with a curated `styleselect` menu.
+
+### JavaScript (`js/block-editor.js`)
+
+Plain JS (no build), uses global `wp.*` APIs. Runs on `wp.domReady`. Reads `mrwEditorOptions` (localized by PHP) to:
+
+- Hide blocks from the inserter via `blocks.registerBlockType` filter
+- Unregister embed/social-link block variations
+- Unregister block styles
+- Unregister inline format types (highlight, inline-image, etc.)
+
+### CSS (`css/`)
+
+- `block-editor.css` — hides editor UI elements via the body classes added by PHP (e.g. `.mrw-block-editor-no-drop-cap`)
+- `blocks.css` — styles block placeholders in the admin (e.g. media buttons)
+
+## Filters / Extensibility
+
+The plugin is filter-driven. Key filters (all in `MRW\SimplifiedEditor` namespace):
+
+- `mrw_hidden_blocks` — full merged list; receives `$context` (screen ID: `post`, `site-editor`, `widgets`)
+- `mrw_hidden_core_blocks`, `mrw_hidden_widget_blocks`, `mrw_hidden_query_blocks`, `mrw_hidden_site_blocks` — category-level sublists
+- `mrw_hidden_embeds`, `mrw_hidden_social_links`
+- `mrw_hidden_block_styles` — keyed array: `[ 'core/image' => ['default', 'rounded'] ]`
+- `mrw_hidden_block_editor_settings` — string slugs like `'drop-cap'`, `'heading-1'`
+- `mrw_jetpack_hidden_blocks`
+- `mrw_block_editor_hide_color_palette`, `mrw_block_editor_hide_gradient_presets`
+- `mrw_mce_text_style` — add items to the classic editor styleselect
+
+## Linting
+
+PHP linting uses PHP_CodeSniffer with the WordPress coding standards ruleset:
+
+```bash
+# Run from plugin root (requires phpcs + WordPress-Coding-Standards installed)
+phpcs --standard=phpcs.xml.dist
+phpcbf --standard=phpcs.xml.dist   # auto-fix
+```
+
+Key rules configured in `phpcs.xml.dist`:
+
+- WordPress ruleset (Yoda conditions excluded)
+- Text domain: `mrw-web-design-simple-tinymce`
+- Global namespace prefix required: `mrw`
+- PHP 8.2+ target (`testVersion="8.2-"`)
+- Minimum supported WP version: 6.7
+
+No JavaScript/CSS linting is configured in this repo.
+
+## Deployment
+
+Releases are deployed to WordPress.org via GitHub Actions (`.github/workflows/deploy.yml`) on any git tag push, using the 10up deploy action. The WordPress.org plugin slug is `mrw-web-design-simple-tinymce`.
+
+Plugin version is set in two places — keep them in sync:
+
+1. `mrwweb-simple-tinymce.php` — `Version:` header and `MRW_SIMPLIFIED_EDITOR_VERSION` constant
+2. `readme.txt` — `Stable tag:` header
+
+## Branch / Release Conventions
+
+- `release` is the main/stable branch (used as PR base)
+- Feature branches follow `issues/{number}-{description}` naming
+- Tags trigger WordPress.org deployment

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rtk ls *)"
+    ]
+  }
+}

--- a/.distignore
+++ b/.distignore
@@ -1,5 +1,6 @@
 /.git
 /.github
 /.wordpress-org
+/.claude
 
 .distignore

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,17 @@
+= 2.15.0 (May 22, 2026) =
+
+* WordPress 7.0 updates
+    * Hide New Blocks: Icon, Breadcrumbs (hidden only in post editor) (enable everywhere with the `mrw_hidden_blocks` filter)
+    * Hide per-block Custom CSS (enable with `custom-css` value in `mrw_hidden_block_editor_settings`)
+    * Hide text indent block setting (enable with `text-indent` value in `mrw_hidden_block_editor_settings`)
+    * Fix hiding Fit Text settings for Paragraph and Heading blocks with new settings approach (Editorializing: The way it should have been all along!)
+    * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
+    * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.
+    * Hide Appearance > Font Library menu item. Show with `font-library` in `mrw_hidden_block_editor_settings`.
+    * Fix Save Draft styling to remain looking like a button
+	* Fix hiding "Insert from URL" button in image block. (Currently not configurable due to editor iframe)
+* Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.
+
 = 2.14.0 (November 18, 2025)
 
 - New minimum supported version: WordPress 6.5

--- a/css/block-editor.css
+++ b/css/block-editor.css
@@ -15,16 +15,6 @@
 }
 
 /*
- Hide the "Upload" button in the editor because it skips the media library
- Hide the "Image from URL" option to discourage hotlinking and not having alt text
- Filter Value: image-file-upload
- */
-.mrw-block-editor-no-image-file-upload .block-editor-media-placeholder__upload-button,
-.mrw-block-editor-no-image-url .block-editor-media-placeholder__url-input-container {
-	display: none;
-}
-
-/*
  Hide the "Text over image" toolbar button when the Cover block is not in the inserter
  Only works for English sites :'(
  */
@@ -69,10 +59,13 @@
 =            "Save draft" Button            =
 ===========================================*/
 /* Styles copied from .is-secondary button class */
-.edit-post-header__settings .editor-post-save-draft {
-	white-space: nowrap;
-	border: 1px solid #a0a5aa;
-	background: #f3f5f6;
+.edit-post-header__settings .editor-post-save-draft,
+/* WP 7.0+ */
+.editor-header__settings .editor-post-save-draft {
+	background: #0000;
+	box-shadow: inset 0 0 0 1px var(--wp-components-color-accent,var(--wp-admin-theme-color,#3858e9)),0 0 0 currentColor;
+	color: var(--wp-components-color-accent,var(--wp-admin-theme-color,#3858e9));
+	outline: 1px solid #0000;
 }
 
 .edit-post-header__settings .editor-post-save-draft:focus:not(:disabled),

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -31,3 +31,12 @@
 .block-editor-media-replace-flow__media-upload-menu .components-form-file-upload {
 	display: none;
 }
+
+/*
+ Hide the "Upload" button in the editor because it skips the media library
+ Hide the "Image from URL" option to discourage hotlinking and not having alt text
+ Filter Value: image-file-upload
+ */
+.block-editor-media-placeholder__url-input-container {
+	display: none;
+}

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -214,6 +214,7 @@ function hidden_blocks() {
 	$hidden_site_blocks = apply_filters(
 		'mrw_hidden_site_blocks',
 		array(
+			'core/breadcrumbs',
 			'core/comments',
 			'core/comments-query-loop',
 			'core/loginout',

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -1,10 +1,14 @@
 <?php
+/**
+ * Block Editor Modifications
+ */
+namespace MRW\SimplifiedEditor;
+
 add_action( 'after_setup_theme', __NAMESPACE__ . '\block_editor_theme_support', 11 );
 /**
  * Make modifications to editor that can be made using default add_theme_support() calls
  */
 function block_editor_theme_support() {
-
 	/*
 	 * Remove pixel-based font sizing
 	 *
@@ -34,7 +38,7 @@ function block_editor_theme_support() {
 
 	/**
 	 * See if the Block Editor Colors plugin is activated. In that case, let it do its thing
-	 * 
+	 *
 	 * @var bool
 	 *
 	 * @see  https://wordpress.org/plugins/block-editor-colors/
@@ -42,7 +46,8 @@ function block_editor_theme_support() {
 	$block_editor_colors_plugin_is_active = in_array( 'block-editor-colors/plugin.php', (array) get_option( 'active_plugins', array() ), true );
 
 	/**
-	 * mrw_block_editor_hide_color_palette filter
+	 * Filter to hide default color palette if the theme has not explicitly registered one or the Block Editor Colors plugin is not active
+	 *
 	 * @since 2.0.0
 	 */
 	$hide_palette = apply_filters(
@@ -50,7 +55,7 @@ function block_editor_theme_support() {
 		empty( $theme_palette )
 	);
 
-	if( $hide_palette && ! $block_editor_colors_plugin_is_active ) {
+	if ( $hide_palette && ! $block_editor_colors_plugin_is_active ) {
 		add_theme_support( 'editor-color-palette' );
 	}
 
@@ -73,7 +78,8 @@ function block_editor_theme_support() {
 	$theme_gradients = get_theme_support( 'editor-gradient-presets' );
 
 	/**
-	 * mrw_block_editor_hide_gradient_presets filter
+	 * Filter to hide default gradient presets if the theme has not explicitly registered any
+	 *
 	 * @since 2.1.0
 	 */
 	$hide_gradients = apply_filters(
@@ -81,7 +87,7 @@ function block_editor_theme_support() {
 		empty( $theme_gradients )
 	);
 
-	if( $hide_gradients ) {
+	if ( $hide_gradients ) {
 		add_theme_support( 'editor-gradient-presets', array() );
 	}
 
@@ -93,131 +99,137 @@ function block_editor_theme_support() {
 	 * @see https://make.wordpress.org/core/2020/07/16/block-patterns-in-wordpress-5-5/
 	 */
 	remove_theme_support( 'core-block-patterns' );
-	
 }
 
-add_action(	'plugins_loaded', __NAMESPACE__ . '\hide_block_directory' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\hide_block_directory' );
 /**
  * Hide the block directory
- * 
+ *
  * @see https://github.com/WordPress/gutenberg/issues/23961#issuecomment-666683997
  */
 function hide_block_directory() {
 
-	if( in_array( 'block-directory', hidden_block_editor_settings() ) ) {
+	if ( in_array( 'block-directory', hidden_block_editor_settings(), true ) ) {
 		remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 		remove_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
 	}
-
 }
 
 /**
  * Define default hidden blocks and allow them to be filtered
  *
  * Note: Blocks are hidden from the inserter rather than unregistered to avoid editor crashing when a hidden block is in the page content
- * 
+ *
  * @return array slugs of all hidden core blocks
  */
 function hidden_blocks() {
 
 	$current_screen = get_current_screen();
-	$context = $current_screen->id;
+	$context        = $current_screen->id;
 
 	/**
-	 * mrw_hidden_core_blocks filter
+	 * Filter `mrw_hidden_core_blocks` allows showing all hidden "Core" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
 	 *
-	 * Allows showing all hidden "Core" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
-	 * 
 	 * @since 2.5.0
 	 */
-	$hidden_core_blocks = apply_filters( 'mrw_hidden_core_blocks', array(
-		'core/accordion',
-		'core/audio',
-		'core/code',
-		'core/details',
-		'core/footnotes',
-		'core/freeform',
-		'core/latest-posts',
-		'core/math',
-		'core/nextpage',
-		'core/preformatted',
-		'core/shortcode',
-		'core/spacer',
-		'core/table',
-		'core/verse',
-		'core/video',
-		'videopress/video', // jetpack
-	), $context );
+	$hidden_core_blocks = apply_filters(
+		'mrw_hidden_core_blocks',
+		array(
+			'core/accordion',
+			'core/audio',
+			'core/code',
+			'core/details',
+			'core/footnotes',
+			'core/freeform',
+			'core/latest-posts',
+			'core/math',
+			'core/nextpage',
+			'core/preformatted',
+			'core/shortcode',
+			'core/spacer',
+			'core/table',
+			'core/verse',
+			'core/video',
+			'videopress/video', // jetpack
+		),
+		$context
+	);
 
 	/**
-	 * mrw_hidden_widget_blocks filter
+	 * Filter `mrw_hidden_widget_blocks` showing all hidden "Widget" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
 	 *
-	 * Allows showing all hidden "Widget" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
-	 * 
 	 * @since 2.5.0
 	 */
-	$hidden_widgets = apply_filters( 'mrw_hidden_widget_blocks', array(
-		'core/archives',
-		'core/calendar',
-		'core/categories',
-		'core/latest-comments',
-		'core/legacy-widget',
-		'core/rss',
-		'core/search',
-		'core/tag-cloud',
-	), $context );
+	$hidden_widgets = apply_filters(
+		'mrw_hidden_widget_blocks',
+		array(
+			'core/archives',
+			'core/calendar',
+			'core/categories',
+			'core/latest-comments',
+			'core/legacy-widget',
+			'core/rss',
+			'core/search',
+			'core/tag-cloud',
+		),
+		$context
+	);
 
 	/**
-	 * mrw_hidden_query_blocks filter
+	 * Filter `mrw_hidden_query_blocks` allows showing all hidden "Query" and "Post" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
 	 *
-	 * Allows showing all hidden "Query" and "Post" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
-	 * 
 	 * @since 2.5.0
 	 */
-	$hidden_query_blocks = apply_filters( 'mrw_hidden_query_blocks', array(
-		'core/avatar',
-		'core/query',
-		'core/query-title',
-		'core/post-title',
-		'core/post-comments-count',
-		'core/post-comments-link',
-		'core/post-content',
-		'core/post-date',
-		'core/post-excerpt',
-		'core/post-featured-image',
-		'core/post-terms',
-		'core/post-author',
-		'core/post-author-biography',
-		'core/read-more',
-		'core/term-count',
-		'core/term-name',
-		'core/term-description',
-		'core/terms-query',
-		'core/post-time-to-read',
-	), $context );
+	$hidden_query_blocks = apply_filters(
+		'mrw_hidden_query_blocks',
+		array(
+			'core/avatar',
+			'core/query',
+			'core/query-title',
+			'core/post-title',
+			'core/post-comments-count',
+			'core/post-comments-link',
+			'core/post-content',
+			'core/post-date',
+			'core/post-excerpt',
+			'core/post-featured-image',
+			'core/post-terms',
+			'core/post-author',
+			'core/post-author-biography',
+			'core/read-more',
+			'core/term-count',
+			'core/term-name',
+			'core/term-description',
+			'core/terms-query',
+			'core/post-time-to-read',
+		),
+		$context
+	);
 
 	/**
-	 * mrw_hidden_site_blocks filter
+	 * Filter `mrw_hidden_site_blocks` allows showing all hidden "Site"/"Theme" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
 	 *
-	 * Allows showing all hidden "Site"/"Theme" blocks by removing them from the hidden list. Use __return_empty_array to unhide all blocks.
-	 * 
 	 * @since 2.5.0
 	 */
-	$hidden_site_blocks = apply_filters( 'mrw_hidden_site_blocks', array(
-		'core/comments',
-		'core/comments-query-loop',
-		'core/loginout',
-		'core/page-list',
-		'core/site-logo',
-		'core/site-tagline',
-		'core/site-title',
-		'core/navigation',
-		'core/post-author-name',
-		'core/post-comments',
-		'core/post-comments-form',
-		'core/post-navigation-link',
-		'core/template-part',
-	), $context );
+	$hidden_site_blocks = apply_filters(
+		'mrw_hidden_site_blocks',
+		array(
+			'core/comments',
+			'core/comments-query-loop',
+			'core/loginout',
+			'core/page-list',
+			'core/site-logo',
+			'core/site-tagline',
+			'core/site-title',
+			'core/navigation',
+			'core/post-author-name',
+			'core/post-comments',
+			'core/post-comments-form',
+			'core/post-navigation-link',
+			'core/template-part',
+		),
+		$context
+	);
 
 	$hidden_blocks = array_merge(
 		$hidden_core_blocks,
@@ -232,25 +244,31 @@ function hidden_blocks() {
 		apply_filters( 'mce_buttons_2', array() )
 	);
 
-	if( ! in_array( 'wp_more', $mce_buttons ) ) {
+	if ( ! in_array( 'wp_more', $mce_buttons, true ) ) {
 		$hidden_blocks[] = 'core/more';
 	}
 
 	/**
-	 * mrw_hidden_blocks filter
+	 * Filter the full list of hidden blocks
+	 *
+	 * @param array $blocks array of all blocks hidden by default
+	 * @param string $context name of editor context
+	 *
 	 * @since 2.3.0
 	 */
 	return apply_filters( 'mrw_hidden_blocks', $hidden_blocks, $context );
-
 }
 
 add_filter( 'mrw_hidden_site_blocks', __NAMESPACE__ . '\show_blocks_in_site_editor', 0, 2 );
 add_filter( 'mrw_hidden_query_blocks', __NAMESPACE__ . '\show_blocks_in_site_editor', 0, 2 );
 /**
- * Show all Query- and Post-related blocks in the Site Editor
+ * Show all query- and post-related blocks in the Site Editor
+ *
+ * @param array  $blocks array of all hidden blocks
+ * @param string $context name of editor context
  */
 function show_blocks_in_site_editor( $blocks, $context ) {
-	if( $context === 'site-editor' ) {
+	if ( $context === 'site-editor' ) {
 		$blocks = array();
 	}
 
@@ -284,11 +302,11 @@ function hidden_embeds() {
 	);
 
 	/**
-	 * mrw_hidden_embeds filter
+	 * Filter list of hidden embeds
+	 *
 	 * @since 2.4.0
 	 */
 	return apply_filters( 'mrw_hidden_embeds', $hidden_embeds );
-
 }
 
 /**
@@ -321,11 +339,11 @@ function hidden_social_links() {
 	);
 
 	/**
-	 * mrw_hidden_social_links filter
+	 * Filter list of hidden social links
+	 *
 	 * @since 2.14.0
 	 */
 	return apply_filters( 'mrw_hidden_social_links', $hidden_social_links );
-
 }
 
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\jetpack_hidden_blocks', 99 );
@@ -339,7 +357,7 @@ function jetpack_hidden_blocks() {
 	if ( ! class_exists( 'Jetpack_Gutenberg' ) ) {
 		return;
 	}
-	
+
 	$jetpack_hidden_block_reason = 'Hidden by MRW Simplified Editor. Use mrw_jetpack_hidden_blocks filter to restore.';
 
 	$jetpack_hidden_content_blocks = array(
@@ -365,7 +383,8 @@ function jetpack_hidden_blocks() {
 	);
 
 	/**
-	 * mrw_jetpack_hidden_blocks filter
+	 * Filter the list of hidden Jetpack blocks
+	 *
 	 * @since 2.3.0
 	 */
 	$mrw_jetpack_hidden_blocks = apply_filters(
@@ -373,43 +392,42 @@ function jetpack_hidden_blocks() {
 		$jetpack_hidden_content_blocks
 	);
 
-	foreach( $mrw_jetpack_hidden_blocks as $block ) {
+	foreach ( $mrw_jetpack_hidden_blocks as $block ) {
 		Jetpack_Gutenberg::set_extension_unavailable(
 			'jetpack/' . $block,
 			$jetpack_hidden_block_reason
 		);
 	}
-
 }
 
 /**
  * Define default hidden block style and allow them to be filtered
- * 
+ *
  * @return array keyed array where keys are a block slug and value is an array containing all block style to remove
  */
 function hidden_block_styles() {
 
 	$hidden_styles = array(
-		'core/image'		=> array( 'default', 'circle-mask', 'rounded' ),
-		'core/button' 		=> array( 'default', 'fill', 'squared', 'outline' ),
-		'core/quote' 		=> array( 'default', 'large' ),
-		'core/separator' 	=> array( 'default', 'wide', 'dots' ),
-		'core/pullquote' 	=> array( 'default', 'solid-color' ),
-		'core/table'		=> array( 'default', 'stripes' ),
-		'core/social-links'	=> array( 'default', 'logos-only', 'pill-shape' ),
+		'core/image'        => array( 'default', 'circle-mask', 'rounded' ),
+		'core/button'       => array( 'default', 'fill', 'squared', 'outline' ),
+		'core/quote'        => array( 'default', 'large' ),
+		'core/separator'    => array( 'default', 'wide', 'dots' ),
+		'core/pullquote'    => array( 'default', 'solid-color' ),
+		'core/table'        => array( 'default', 'stripes' ),
+		'core/social-links' => array( 'default', 'logos-only', 'pill-shape' ),
 	);
 
 	/**
-	 * mrw_hidden_block_styles filter
+	 * Filter the list of hidden block styles
+	 *
 	 * @since 2.3.0
 	 */
-	return apply_filters( 'mrw_hidden_block_styles', $hidden_styles	);
-
+	return apply_filters( 'mrw_hidden_block_styles', $hidden_styles );
 }
 
 /**
  * Return filtered array of Block Editor Features/Settings to hide
- * 
+ *
  * @return array every option to hide via CSS or JS
  */
 function hidden_block_editor_settings() {
@@ -455,18 +473,19 @@ function hidden_block_editor_settings() {
 	);
 
 	/**
-	 * mrw_hidden_core_blocks filter
+	 * Filter the list of hidden block editor settings
+	 *
 	 * @since 2.3.0
 	 */
 	return apply_filters( 'mrw_hidden_block_editor_settings', $hidden_block_editor_settings );
-
 }
 
 add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\block_editor_settings', 99, 2 );
 /**
  * Make changes to editor settings, accounting for plugin filters, via the core block_editor_settings filter
- * 
- * @param  array $editor_settings default editor settings
+ *
+ * @param  array  $editor_settings default editor settings
+ * @param  string $context name of editor context
  * @return array                  modified settings
  *
  * @see https://github.com/joppuyo/remove-drop-cap/blob/v1.1.0/remove-drop-cap.php#L22
@@ -476,113 +495,112 @@ function block_editor_settings( $editor_settings, $context ) {
 	$hidden_settings = hidden_block_editor_settings();
 
 	/* Border */
-	if( in_array( 'border', $hidden_settings ) ) {
-		$editor_settings['__experimentalFeatures']['border'] = [];
+	if ( in_array( 'border', $hidden_settings, true ) ) {
+		$editor_settings['__experimentalFeatures']['border'] = array();
 	}
 
 	/* Border Radius, Button */
-	if( in_array( 'border-radius', $hidden_settings ) ) {
-		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['radius'] = false;	
+	if ( in_array( 'border-radius', $hidden_settings, true ) ) {
+		$editor_settings['__experimentalFeatures']['blocks']['core/button']['border']['radius'] = false;
 	}
 
 	/* Default Color Pallete */
-	if( in_array( 'default-color-palette', $hidden_settings ) ) {
+	if ( in_array( 'default-color-palette', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['color']['defaultPalette'] = false;
 	}
-	
+
 	/* Default Gradients */
-	if( in_array( 'default-gradients', $hidden_settings ) ) {
+	if ( in_array( 'default-gradients', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['color']['defaultGradients'] = false;
 	}
 
 	/* Drop Cap */
-	if( in_array( 'drop-cap', $hidden_settings ) ) {
+	if ( in_array( 'drop-cap', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['dropCap'] = false;
 	}
 
 	/* Duotone */
-	if( in_array( 'duotone', $hidden_settings ) ) {
+	if ( in_array( 'duotone', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['color']['defaultDuotone'] = false;
-		$editor_settings['__experimentalFeatures']['color']['customDuotone'] = false;
+		$editor_settings['__experimentalFeatures']['color']['customDuotone']  = false;
 	}
 
 	/* Font Style */
-	if( in_array( 'font-style', $hidden_settings ) ) {
+	if ( in_array( 'font-style', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
 	}
 
 	/* Font Weight */
-	if( in_array( 'font-weight', $hidden_settings ) ) {
+	if ( in_array( 'font-weight', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontWeight'] = false;
 	}
 
 	/* Gap and Margin */
-	if( in_array( 'spacing', $hidden_settings ) ) {
-		$editor_settings['__experimentalFeatures']['spacing'] = [];
+	if ( in_array( 'spacing', $hidden_settings, true ) ) {
+		$editor_settings['__experimentalFeatures']['spacing'] = array();
 	}
 
 	/* Image Background (just Group for not, not including Cover) */
-	if( in_array( 'image-background', $hidden_settings ) ) {
-		$editor_settings['__experimentalFeatures']['background']['backgroundImage'] = false;	
+	if ( in_array( 'image-background', $hidden_settings, true ) ) {
+		$editor_settings['__experimentalFeatures']['background']['backgroundImage'] = false;
 	}
 
 	/* Letter Spacing */
-	if( in_array( 'letter-spacing', $hidden_settings ) ) {
+	if ( in_array( 'letter-spacing', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['letterSpacing'] = false;
 	}
 
 	/* Line Height */
-	if( in_array( 'line-height', $hidden_settings ) ) {
+	if ( in_array( 'line-height', $hidden_settings, true ) ) {
 		$editor_settings['enableCustomLineHeight'] = false;
 	}
 
 	/* Padding */
-	if( in_array( 'padding', $hidden_settings ) ) {
+	if ( in_array( 'padding', $hidden_settings, true ) ) {
 		$editor_settings['enableCustomSpacing'] = false;
 	}
 
 	/* Pullquote Border */
-	if( in_array( 'pullquote-border', $hidden_settings ) ) {
-		$editor_settings['__experimentalFeatures']['blocks']['core/pullquote']['border'] = [];
+	if ( in_array( 'pullquote-border', $hidden_settings, true ) ) {
+		$editor_settings['__experimentalFeatures']['blocks']['core/pullquote']['border'] = array();
 	}
 
 	/* Shadow */
-	if( in_array( 'shadow', $hidden_settings ) ) {
+	if ( in_array( 'shadow', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['shadow']['defaultPresets'] = false;
 	}
 
 	/* Text Decoration */
-	if( in_array( 'text-decoration', $hidden_settings ) ) {
+	if ( in_array( 'text-decoration', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['textDecoration'] = false;
 	}
 
 	/* Text Orientation */
-	if( in_array( 'text-orientation', $hidden_settings ) ) {
+	if ( in_array( 'text-orientation', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['writingMode'] = false;
 	}
 
 	/* Text Transform */
-	if( in_array( 'text-transform', $hidden_settings ) ) {
+	if ( in_array( 'text-transform', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['textTransform'] = false;
 	}
 
 	/* Min Height on the Group block (not the cover block) */
-	if( in_array( 'min-height-group', $hidden_settings ) ) {
+	if ( in_array( 'min-height-group', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['dimensions']['minHeight'] = false;
 	}
 
 	/* Position Sticky */
-	if( in_array( 'sticky-position', $hidden_settings ) ) {
+	if ( in_array( 'sticky-position', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['position']['sticky'] = false;
 	}
 
 	return $editor_settings;
-
 }
 
 /**
  * Prepare all plugin options (after being filtered) for use in JavaScript
- * 
+ *
  * @return array all hidden blocks, block styles, and block editor settings
  */
 function block_editor_js_config() {
@@ -591,37 +609,27 @@ function block_editor_js_config() {
 
 	// Note: using array_values to ensure this is passed as an array and not an object
 
-	/*==============================
-	=            Blocks            =
-	==============================*/
+	/* Blocks */
 	$js_options['hiddenBlocks'] = array_values( hidden_blocks() );
 
-	/*========================================
-	=            Embed Variations            =
-	========================================*/
+	/* Embed Variations */
 	$js_options['hiddenEmbeds'] = array_values( hidden_embeds() );
 
-	/*========================================
-	=            Social Links                =
-	========================================*/
+	/* Social Links */
 	$js_options['hiddenSocialLinks'] = array_values( hidden_social_links() );
 
-	/*====================================
-	=            Block Styles            =
-	======================================*/
+	/* Block Styles */
+	$hidden_styles = array();
 	foreach ( hidden_block_styles() as $block => $styles ) {
-		$hidden_styles[$block] = array_values( $styles );
+		$hidden_styles[ $block ] = array_values( $styles );
 	}
 
 	$js_options['hiddenStyles'] = $hidden_styles;
 
-	/*================================
-	=            Features            =
-	================================*/
+	/* Features */
 	$js_options['hiddenSettings'] = array_values( hidden_block_editor_settings() );
 
 	return $js_options;
-
 }
 
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\block_editor_assets' );
@@ -632,20 +640,20 @@ function block_editor_assets() {
 
 	/**
 	 * Ensure the correct dependencies depending on the editor being used
-	 * 
+	 *
 	 * Thank you Sally CJ! https://wordpress.stackexchange.com/a/413631/9844
 	 */
 	$script_dependencies = array( 'wp-blocks', 'wp-dom-ready' );
-	$screen = get_current_screen();
-	$context = $screen ? $screen->id : '';
-	switch( $context ) {
+	$screen              = get_current_screen();
+	$context             = $screen ? $screen->id : '';
+	switch ( $context ) {
 		case 'widgets':
 			$script_dependencies[] = 'wp-edit-widgets';
 			break;
 		case 'site-editor':
 			$script_dependencies[] = 'wp-edit-site';
 			break;
-		case 'page':	
+		case 'page':
 		case 'post':
 			$script_dependencies[] = 'wp-edit-post';
 			break;
@@ -656,14 +664,14 @@ function block_editor_assets() {
 
 	wp_enqueue_style(
 		'mrw-block-editor-css',
-		plugins_url( 'css/block-editor.css', dirname(__FILE__) ),
+		plugins_url( 'css/block-editor.css', __DIR__ ),
 		array(),
 		MRW_SIMPLIFIED_EDITOR_VERSION
 	);
 
 	wp_register_script(
 		'mrw-block-editor-js',
-		plugins_url( 'js/block-editor.js', dirname(__FILE__) ),
+		plugins_url( 'js/block-editor.js', __DIR__ ),
 		$script_dependencies,
 		MRW_SIMPLIFIED_EDITOR_VERSION,
 		array( 'in_footer' => true )
@@ -676,15 +684,19 @@ function block_editor_assets() {
 	);
 
 	wp_enqueue_script( 'mrw-block-editor-js' );
-
 }
 
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\block_styles' );
+/**
+ * Enqueue CSS that styles blocks, not the editor. For example, changing the display of the media placeholder block
+ *
+ * @return void
+ */
 function block_styles() {
-	if( is_admin() ) {
+	if ( is_admin() ) {
 		wp_enqueue_style(
 			'mrw-blocks-css',
-			plugins_url( 'css/blocks.css', dirname(__FILE__) ),
+			plugins_url( 'css/blocks.css', __DIR__ ),
 			array(),
 			MRW_SIMPLIFIED_EDITOR_VERSION
 		);
@@ -694,7 +706,7 @@ function block_styles() {
 add_action( 'admin_body_class', __NAMESPACE__ . '\block_editor_settings_admin_classes' );
 /**
  * Apply body classes to admin for each features that are hidden via CSS
- * 
+ *
  * @param  array $classes list of hidden features
  * @return array
  */
@@ -702,23 +714,19 @@ function block_editor_settings_admin_classes( $classes ) {
 
 	$current_screen = get_current_screen();
 
-	if( isset( $current_screen->is_block_editor ) && (bool) $current_screen->is_block_editor ) {
-		$prefix = ' mrw-block-editor-no-';
+	if ( isset( $current_screen->is_block_editor ) && (bool) $current_screen->is_block_editor ) {
+		$prefix                       = ' mrw-block-editor-no-';
 		$hidden_block_editor_settings = hidden_block_editor_settings();
-		$hidden_blocks = hidden_blocks();
-		
-		foreach( $hidden_block_editor_settings as $setting ) {
+		$hidden_blocks                = hidden_blocks();
+
+		foreach ( $hidden_block_editor_settings as $setting ) {
 			$classes .= $prefix . sanitize_title_with_dashes( $setting );
 		}
 
-		if( in_array( 'core/cover', $hidden_blocks ) ) {
+		if ( in_array( 'core/cover', $hidden_blocks, true ) ) {
 			$classes .= $prefix . 'cover-block';
 		}
-
 	}
 
-
-
 	return $classes;
-
 }

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -446,6 +446,7 @@ function hidden_block_editor_settings() {
 		'duotone',
 		'fit-text-heading',
 		'fit-text-paragraph',
+		'font-library',
 		'font-weight',
 		'font-style',
 		'heading-1',
@@ -563,6 +564,11 @@ function block_editor_settings( $editor_settings, $context ) {
 		$editor_settings['__experimentalFeatures']['color']['customDuotone']  = false;
 	}
 
+	/* Font Library - Seems like this doesn't work, leaving for now: https://github.com/WordPress/developer-blog-content/issues/337*/
+	if ( in_array( 'font-library', $hidden_settings, true ) ) {
+		$editor_settings['fontLibraryEnabled'] = false;
+	}
+
 	/* Font Style */
 	if ( in_array( 'font-style', $hidden_settings, true ) ) {
 		$editor_settings['__experimentalFeatures']['typography']['fontStyle'] = false;
@@ -634,6 +640,22 @@ function block_editor_settings( $editor_settings, $context ) {
 	}
 
 	return $editor_settings;
+}
+
+add_action( 'admin_menu', __NAMESPACE__ . '\remove_font_library_menu' );
+/**
+ * Removes the new Font Library menu item for Classic in WP 7.0
+ * 
+ * @since 2.15.0
+ *
+ * @return void
+ */
+function remove_font_library_menu() {
+	$hidden_settings = hidden_block_editor_settings();
+
+	if ( in_array( 'font-library', $hidden_settings, true ) ) {
+		remove_submenu_page( 'themes.php', 'font-library.php' );
+	}
 }
 
 /**

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -491,7 +491,10 @@ add_filter( 'block_type_metadata', __NAMESPACE__ . '\filter_block_type_metadata'
  * Filters the metadata provided for registering a block type.
  *
  * @param array $metadata Metadata for registering a block type.
+ * 
  * @return array Metadata for registering a block type.
+ * 
+ * @since 2.15.0
  */
 function filter_block_type_metadata( $metadata ) {
 	$hidden_settings = hidden_block_editor_settings();
@@ -532,6 +535,8 @@ add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\block_editor_settings
 function block_editor_settings( $editor_settings, $context ) {
 
 	$hidden_settings = hidden_block_editor_settings();
+
+	do_action( 'qm/debug', $editor_settings );
 
 	/* Border */
 	if ( in_array( 'border', $hidden_settings, true ) ) {

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -470,6 +470,7 @@ function hidden_block_editor_settings() {
 		'spacing',
 		'sticky-position',
 		'text-decoration',
+		'text-indent',
 		'text-orientation',
 		'text-transform',
 	);
@@ -491,9 +492,17 @@ add_filter( 'block_type_metadata', __NAMESPACE__ . '\filter_block_type_metadata'
  */
 function filter_block_type_metadata( $metadata ) {
 	$hidden_settings = hidden_block_editor_settings();
+
+	/* Custom CSS */
 	if ( in_array( 'custom-css', $hidden_settings, true ) ) {
         $metadata['supports']['customCSS'] = false;
     }
+
+	/* Text Indent */
+	if ( in_array( 'text-indent', $hidden_settings, true ) ) {
+		$metadata['supports']['typography']['textIndent'] = false;
+	}
+	
 	return $metadata;
 }
 

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -450,6 +450,7 @@ function hidden_block_editor_settings() {
 		'heading-1',
 		'heading-5',
 		'heading-6',
+		'heading-variations',
 		'highlight',
 		'image-background',
 		'image-dimensions',

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -491,9 +491,9 @@ add_filter( 'block_type_metadata', __NAMESPACE__ . '\filter_block_type_metadata'
  * Filters the metadata provided for registering a block type.
  *
  * @param array $metadata Metadata for registering a block type.
- * 
+ *
  * @return array Metadata for registering a block type.
- * 
+ *
  * @since 2.15.0
  */
 function filter_block_type_metadata( $metadata ) {
@@ -501,8 +501,8 @@ function filter_block_type_metadata( $metadata ) {
 
 	/* Custom CSS */
 	if ( in_array( 'custom-css', $hidden_settings, true ) ) {
-        $metadata['supports']['customCSS'] = false;
-    }
+		$metadata['supports']['customCSS'] = false;
+	}
 
 	/* Text Indent */
 	if ( in_array( 'text-indent', $hidden_settings, true ) ) {
@@ -513,7 +513,7 @@ function filter_block_type_metadata( $metadata ) {
 	if ( $metadata['name'] === 'core/paragraph' && in_array( 'fit-text-paragraph', $hidden_settings, true ) ) {
 		$metadata['supports']['typography']['fitText'] = false;
 	}
-	
+
 	/* Fit Text in WP7.0+ */
 	if ( $metadata['name'] === 'core/heading' && in_array( 'fit-text-heading', $hidden_settings, true ) ) {
 		$metadata['supports']['typography']['fitText'] = false;
@@ -522,21 +522,18 @@ function filter_block_type_metadata( $metadata ) {
 	return $metadata;
 }
 
-add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\block_editor_settings', 99, 2 );
+add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\block_editor_settings', 99 );
 /**
  * Make changes to editor settings, accounting for plugin filters, via the core block_editor_settings filter
  *
- * @param  array  $editor_settings default editor settings
- * @param  string $context name of editor context
+ * @param  array $editor_settings default editor settings
  * @return array                  modified settings
  *
  * @see https://github.com/joppuyo/remove-drop-cap/blob/v1.1.0/remove-drop-cap.php#L22
  */
-function block_editor_settings( $editor_settings, $context ) {
+function block_editor_settings( $editor_settings ) {
 
 	$hidden_settings = hidden_block_editor_settings();
-
-	do_action( 'qm/debug', $editor_settings );
 
 	/* Border */
 	if ( in_array( 'border', $hidden_settings, true ) ) {
@@ -650,7 +647,7 @@ function block_editor_settings( $editor_settings, $context ) {
 add_action( 'admin_menu', __NAMESPACE__ . '\remove_font_library_menu' );
 /**
  * Removes the new Font Library menu item for Classic in WP 7.0
- * 
+ *
  * @since 2.15.0
  *
  * @return void

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -141,6 +141,7 @@ function hidden_blocks() {
 			'core/details',
 			'core/footnotes',
 			'core/freeform',
+			'core/icon',
 			'core/latest-posts',
 			'core/math',
 			'core/nextpage',

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -436,6 +436,7 @@ function hidden_block_editor_settings() {
 		'block-directory',
 		'border',
 		'border-radius',
+		'custom-css',
 		'default-color-palette',
 		'default-gradients',
 		'default-style-variation',
@@ -478,6 +479,21 @@ function hidden_block_editor_settings() {
 	 * @since 2.3.0
 	 */
 	return apply_filters( 'mrw_hidden_block_editor_settings', $hidden_block_editor_settings );
+}
+
+add_filter( 'block_type_metadata', __NAMESPACE__ . '\filter_block_type_metadata', 99 );
+/**
+ * Filters the metadata provided for registering a block type.
+ *
+ * @param array $metadata Metadata for registering a block type.
+ * @return array Metadata for registering a block type.
+ */
+function filter_block_type_metadata( $metadata ) {
+	$hidden_settings = hidden_block_editor_settings();
+	if ( in_array( 'custom-css', $hidden_settings, true ) ) {
+        $metadata['supports']['customCSS'] = false;
+    }
+	return $metadata;
 }
 
 add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\block_editor_settings', 99, 2 );

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -502,7 +502,17 @@ function filter_block_type_metadata( $metadata ) {
 	if ( in_array( 'text-indent', $hidden_settings, true ) ) {
 		$metadata['supports']['typography']['textIndent'] = false;
 	}
+
+	/* Fit Text in WP7.0+ */
+	if ( $metadata['name'] === 'core/paragraph' && in_array( 'fit-text-paragraph', $hidden_settings, true ) ) {
+		$metadata['supports']['typography']['fitText'] = false;
+	}
 	
+	/* Fit Text in WP7.0+ */
+	if ( $metadata['name'] === 'core/heading' && in_array( 'fit-text-heading', $hidden_settings, true ) ) {
+		$metadata['supports']['typography']['fitText'] = false;
+	}
+
 	return $metadata;
 }
 

--- a/inc/classic-editor.php
+++ b/inc/classic-editor.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Classic Editor modifications
+ */
 namespace MRW\SimplifiedEditor;
 
 add_filter( 'mce_buttons', __NAMESPACE__ . '\mce_buttons_1', 0 );
@@ -8,15 +11,15 @@ add_filter( 'mce_buttons', __NAMESPACE__ . '\mce_buttons_1', 0 );
  *
  * @since  1.0.0
  * @access public
- * @param  $buttons array the default TinyMCE buttons
+ * @param  array $buttons the default TinyMCE buttons *
  * @return array the modified TinyMCE buttons
  * @see    http://codex.wordpress.org/TinyMCE_Custom_Buttons
  */
 function mce_buttons_1( $buttons ) {
 
 	$buttons = array(
-		0 => 'styleselect',
-		5 => 'bold',
+		0  => 'styleselect',
+		5  => 'bold',
 		10 => 'italic',
 		15 => 'link',
 		20 => 'unlink',
@@ -32,13 +35,13 @@ function mce_buttons_1( $buttons ) {
 	);
 
 	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
-	if( $screen && isset( $screen->is_block_editor ) && $screen->is_block_editor ) {
+	if ( $screen && isset( $screen->is_block_editor ) && $screen->is_block_editor ) {
 		$buttons[1000] = 'wp_add_media';
 		unset( $buttons[75] );
 	}
 
 	if ( ! wp_is_mobile() ) {
-		$buttons[70] = 'wp_help'; 
+		$buttons[70] = 'wp_help';
 	}
 
 	return $buttons;
@@ -57,8 +60,8 @@ add_filter( 'tiny_mce_before_init', __NAMESPACE__ . '\mce_init', 0 );
  *
  * @since  1.0.0
  * @access public
- * @param  $args array existing TinyMCE arguments
- * @return $args array modified TinyMCE arguments
+ * @param  array $args existing TinyMCE arguments
+ * @return array $args modified TinyMCE arguments
  * @see    http://wordpress.stackexchange.com/a/128950/9844
  */
 function mce_init( $args ) {
@@ -108,16 +111,16 @@ function mce_init( $args ) {
 
 	/**
 	 * Filter to add styles to "Text Styles" submenu in `styleselect`.
-	 * 
+	 *
 	 * @since  1.0.0
-	 * 
+	 *
 	 * @param array $text_styles array of arrays, each defining a style
-	 * 
+	 *
 	 * @see http://wordpress.stackexchange.com/a/128950/9844
 	 */
 	$text_styles = array();
 	$text_styles = apply_filters( 'mrw_mce_text_style', $text_styles );
-	if ( ! empty( $text_styles) ) {
+	if ( ! empty( $text_styles ) ) {
 		// Define the "Text Style" submenu
 		$text_styles = array(
 			'title' => esc_attr__( 'Custom Styles', 'mrw-web-design-simple-tinymce' ),

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -11,6 +11,29 @@ wp.hooks.addFilter( 'blocks.registerBlockType', 'hideBlocks', ( blockSettings, b
 		});
 	}
 
+	if ( blockName === 'core/heading' && Array.isArray( blockSettings.variations ) ) {
+		const hiddenLevels = [];
+		[ 1, 5, 6 ].forEach( ( level ) => {
+			if ( -1 < mrwEditorOptions.hiddenSettings.indexOf( 'heading-' + level ) ) {
+				hiddenLevels.push( 'h' + level );
+			}
+		} );
+		if ( hiddenLevels.length > 0 ) {
+			return Object.assign( {}, blockSettings, {
+				variations: blockSettings.variations.map( ( variation ) => {
+					/* Fully hide heading levels from the editor */
+					if ( -1 < hiddenLevels.indexOf( variation.name ) ) {
+						return Object.assign( {}, variation, { scope: [] } );
+					}
+					/* Hide all heading variations from the inserter  */
+					else if ( -1 < mrwEditorOptions.hiddenSettings.indexOf( 'heading-variations' ) ) {
+						return Object.assign( {}, variation, { scope: [ 'transform' ] } );
+					}
+				} )
+			} );
+		}
+	}
+
 	return blockSettings;
 });
 

--- a/js/block-editor.js
+++ b/js/block-editor.js
@@ -5,12 +5,14 @@
  */
 wp.hooks.addFilter( 'blocks.registerBlockType', 'hideBlocks', ( blockSettings, blockName ) => {
 
+	/* Hide blocks from the inserter */
 	if ( -1 < mrwEditorOptions.hiddenBlocks.indexOf( blockName ) ) {
 		return Object.assign({}, blockSettings, {
 			supports: Object.assign( {}, blockSettings.supports, {inserter: false} )
 		});
 	}
 
+	/* Hide heading variation levels complete and all heading variations from the inserter */
 	if ( blockName === 'core/heading' && Array.isArray( blockSettings.variations ) ) {
 		const hiddenLevels = [];
 		[ 1, 5, 6 ].forEach( ( level ) => {

--- a/mrwweb-simple-tinymce.php
+++ b/mrwweb-simple-tinymce.php
@@ -3,7 +3,7 @@
  * Plugin Name: MRW Simplified Editor
  * Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
  * Description: Streamlines the WordPress editor to focus users on consistent formatting and semantic content.
- * Version: 2.15.0-beta
+ * Version: 2.15.0
  * Author: Mark Root-Wiley
  * Author URI: https://MRWweb.com
  * Text Domain: mrw-web-design-simple-tinymce
@@ -12,7 +12,7 @@
  * Primary Branch: release
  */
 
-DEFINE( 'MRW_SIMPLIFIED_EDITOR_VERSION', '2.15.0-beta' );
+DEFINE( 'MRW_SIMPLIFIED_EDITOR_VERSION', '2.15.0' );
 
 require_once 'inc/classic-editor.php';
 require_once 'inc/block-editor.php';

--- a/mrwweb-simple-tinymce.php
+++ b/mrwweb-simple-tinymce.php
@@ -1,18 +1,18 @@
 <?php
-/*
-* Plugin Name: MRW Simplified Editor
-* Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
-* Description: Streamlines the WordPress editor to focus users on consistent formatting and semantic content.
-* Version: 2.14.0
-* Author: Mark Root-Wiley
-* Author URI: https://MRWweb.com
-* Text Domain: mrw-web-design-simple-tinymce
-* License: GPLv2 or later
-* GitHub Plugin URI: mrwweb/mrw-simplified-editor-wordpress
-* Primary Branch: release
-*/
+/**
+ * Plugin Name: MRW Simplified Editor
+ * Plugin URI: https://MRWweb.com/wordpress-plugins/mrw-web-design-simple-tinymce/
+ * Description: Streamlines the WordPress editor to focus users on consistent formatting and semantic content.
+ * Version: 2.15.0-beta
+ * Author: Mark Root-Wiley
+ * Author URI: https://MRWweb.com
+ * Text Domain: mrw-web-design-simple-tinymce
+ * License: GPLv2 or later
+ * GitHub Plugin URI: mrwweb/mrw-simplified-editor-wordpress
+ * Primary Branch: release
+ */
 
-DEFINE( 'MRW_SIMPLIFIED_EDITOR_VERSION', '2.14.0' );
+DEFINE( 'MRW_SIMPLIFIED_EDITOR_VERSION', '2.15.0-beta' );
 
-include_once( 'inc/classic-editor.php' );
-include_once( 'inc/block-editor.php' );
+require_once 'inc/classic-editor.php';
+require_once 'inc/block-editor.php';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,6 +35,8 @@
     <rule ref="WordPress">
         <!-- I'm pretty sure this rule is on the way out. I understand why people recommend it and I think it's more readable the other way -->
         <exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+        <!-- I'm also using namespaces, so I'm not worried about this. -->
+        <exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed" />
     </rule>
     
     <!-- #############################################################################

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+    <!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+    <!-- See https://github.com/WordPress/WordPress-Coding-Standards -->
+    <!-- See https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+    <!-- Set a description for this ruleset. -->
+    <description>A custom set of code standard rules to check for WordPress themes.</description>
+    <!-- #############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	############################################################################# -->
+    <!-- Pass some flags to PHPCS:
+		 p flag: Show progress of the run.
+		 s flag: Show sniff codes in all reports. -->
+    <arg value="ps" />
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath"
+         value="./" />
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel"
+         value="8" />
+    <!-- Check PHP files only. JavaScript and CSS files are checked separately using the @wordpress/scripts package. -->
+    <arg name="extensions"
+         value="php" />
+    <!-- Check all files in this directory and the directories below it. -->
+    <file>.</file>
+    <!-- Exclude patterns. -->
+    <exclude-pattern>/.github/*</exclude-pattern>
+    <exclude-pattern>/.wordpress-org/*</exclude-pattern>
+    <exclude-pattern>/.claude/*</exclude-pattern>
+
+    <!-- #############################################################################
+	USE THE WordPress AND THE Theme Review RULESET
+	############################################################################# -->
+    <rule ref="WordPress">
+        <!-- I'm pretty sure this rule is on the way out. I understand why people recommend it and I think it's more readable the other way -->
+        <exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+    </rule>
+    
+    <!-- #############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	############################################################################# -->
+    <!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="mrw-web-design-simple-tinymce" />
+            </property>
+        </properties>
+    </rule>
+    <!-- Set the minimum supported WP version. This is used by several sniffs.
+		 The minimum version set here should be in line with the minimum WP version
+		 as set in the "Requires at least" tag in the readme.txt file. -->
+    <config name="minimum_supported_wp_version"
+            value="6.7" />
+    <rule ref="WordPress.Arrays.MultipleStatementAlignment">
+        <properties>
+            <!-- No need to adjust alignment of large arrays when the item with the largest key is removed. -->
+            <property name="exact"
+                      value="false" />
+            <!-- Don't align multi-line items if ALL items in the array are multi-line. -->
+            <property name="alignMultilineItems"
+                      value="!=100" />
+            <!-- Array assignment operator should always be on the same line as the array key. -->
+            <property name="ignoreNewlines"
+                      value="false" />
+        </properties>
+    </rule>
+    <!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array">
+                <element value="mrw" />
+            </property>
+        </properties>
+    </rule>
+    <!-- #############################################################################
+	USE THE PHPCompatibility RULESET
+	############################################################################# -->
+    <config name="testVersion"
+            value="8.2-" />
+    <!-- <rule ref="PHPCompatibilityWP" /> -->
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+        <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+        <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
+        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+    </rule>
+</ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,10 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 1. The Block Editor simplified, here with no colors or drop caps for the Paragraph block.
 
 == Changelog ==
+= 2.15.0 (TBD) =
+
+* Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.
+
 = 2.14.0 (November 18, 2025)
 
 - New minimum supported version: WordPress 6.5

--- a/readme.txt
+++ b/readme.txt
@@ -80,9 +80,9 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 = 2.15.0 (TBD) =
 
 * WordPress 7.0 updates
+    * Hide New Blocks: Icon, Breadcrumbs (hidden only in post editor) (enable everywhere with the `mrw_hidden_blocks` filter)
     * Hide per-block Custom CSS (enable with `custom-css` value in `mrw_hidden_block_editor_settings`)
     * Hide text indent block setting (enable with `text-indent` value in `mrw_hidden_block_editor_settings`)
-    * Hide the core breadcrumbs block from the post editor (enable everywhere with the `mrw_hidden_blocks` filter)
     * Fix hiding Fit Text settings for Paragraph and Heading blocks with new settings approach (Editorializing: The way it should have been all along!)
     * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
     * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,13 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 == Changelog ==
 = 2.15.0 (TBD) =
 
+* WordPress 7.0 updates
+    * Hide per-block Custom CSS (enable with `custom-css` value in `mrw_hidden_block_editor_settings`)
+    * Hide text indent block setting (enable with `text-indent` value in `mrw_hidden_block_editor_settings`)
+    * Hide the core breadcrumbs block from the post editor (enable everywhere with the `mrw_hidden_blocks` filter)
+    * Fix hiding Fit Text settings for Paragraph and Heading blocks with new settings approach (Editorializing: The way it should have been all along!)
+    * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
+    * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.
 * Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.
 
 = 2.14.0 (November 18, 2025)

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: mrwweb
 Tags: Block Editor, Blocks, Gutenberg, Editor Styles, Editor
 Requires at least: 6.5
 Requires PHP: 5.6.20
-Tested up to: 6.9
-Stable tag: 2.14.0
+Tested up to: 7.0
+Stable tag: 2.15.0
 Donate link: https://www.paypal.me/rootwiley
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -21,11 +21,13 @@ Help your site's editors create semantic content and style it with the theme for
 
 = Block Editor Features =
 
-This plugin greatly simplifies the block editor by **hiding** all of the following features. Filters are provided for developers to adjust what is hidden (including making it easier to hide additional blocks).
+This plugin greatly simplifies the block editor by **hiding** a significant number of blocks, block settings, and other editor-facing features.
 
-- **Infrequently Used Core Blocks** such as Verse, Table, Audio, Video, etc., and all Query- and Site-related blocks. See FAQ for [full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
+The plugin is regularly updated following major WordPress version updates. Filters are provided for developers to adjust what is hidden (including making it easier to hide additional blocks).
+
+- **Infrequently Used Core Blocks** such as Verse, Table, Audio, Video, etc., and all Query- and Site-related blocks when using the Post editor. See FAQ for [full list of hidden blocks](https://wordpress.org/plugins/mrw-web-design-simple-tinymce/#faq).
 - **All Core Block Styles and the "Default style" feature**
-- **Some Block Editor Settings:** Drop Cap, Heading 1, Heading 5, Heading 6, font sizing by pixel, open links in new tabs (mostly hidden), duotone, text styles like line-height and letter spacing, inline formats including Highlight and Inline Image, etc.
+- **Some Block Editor Settings:** Drop Cap, Text-indent, Heading 1, Heading 5, Heading 6, font sizing by pixel, open links in new tabs (mostly hidden), duotone, text styles like line-height and letter spacing, inline formats including Highlight and Inline Image, etc.
 - **Default color, gradient, and duotone settings** (Custom theme palettes/settings are never hidden)
 - **Core Block Patterns (WP 5.5+)**
 - **Block Directory (WP 5.5+)**
@@ -50,11 +52,11 @@ Due to frequent changes to the block editor, features are only guaranteed for th
 
 **Hidden Core Blocks:**
 
-- **Text & Media Blocks:** Audio, Classic/Freeform, Code, Details, Footnotes, Next Page, Preformatted, Shortcode, Spacer, Table, Verse, Video
+- **Text & Media Blocks:** Accordion, Audio, Classic/Freeform, Code, Details, Icon, Footnotes, Next Page, Preformatted, Shortcode, Spacer, Table, Verse, Video
 - **Widget Blocks:** Archives, Calendar, Categories, Latest Comments, RSS, Search, Tag Cloud
 - **Query-Related Blocks**: Query, Archive Title (Query Title), Post Title, Post Content, Post Author, Post Date, Post Excerpt, Post Featured Image, Post Tags & Categories (Post Terms), Term Description
 Page List
-- **FSE Blocks:** Login/Out, Page List, Site Logo, Site Tagline, Site Title, Navigation, Next Post, Previous Post, Post Comments, Comments Query, Read More, Avatar, Post Author Biography, Post Comments Form
+- **FSE Blocks:**  Breadcrumbs, Login/Out, Page List, Site Logo, Site Tagline, Site Title, Navigation, Next Post, Previous Post, Post Comments, Comments Query, Read More, Avatar, Post Author Biography, Post Comments Form
 
 **Hidden Core Embeds:**
 
@@ -77,7 +79,7 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 1. The Block Editor simplified, here with no colors or drop caps for the Paragraph block.
 
 == Changelog ==
-= 2.15.0 (TBD) =
+= 2.15.0 (May 22, 2026) =
 
 * WordPress 7.0 updates
     * Hide New Blocks: Icon, Breadcrumbs (hidden only in post editor) (enable everywhere with the `mrw_hidden_blocks` filter)
@@ -87,6 +89,8 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
     * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
     * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.
     * Hide Appearance > Font Library menu item. Show with `font-library` in `mrw_hidden_block_editor_settings`.
+    * Fix Save Draft styling to remain looking like a button
+    * Fix hiding "Insert from URL" button in image block. (Currently not configurable due to editor iframe)
 * Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.
 
 = 2.14.0 (November 18, 2025)
@@ -112,34 +116,9 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
 - [Fix] Hide Headings 1, 5, and 6 in WordPress 6.5+
 - Add new `blueprint.json` file to support plugin repository playground feature
 
-= 2.12.1 (November 30, 2023) =
-- Fix ability to unhide newly-hidden inline formats (Footnote, highlight, inline image, inline code, and keyboard)
-
-= 2.12.0 (November 3, 2023) =
-- WordPress 6.4 compatibility
-- Fix error that hid custom theme duotone options
-- Fully hide Footnotes inserter unless the block is unhidden via `mrw_hidden_blocks` filter
-- Hide "Highlight", "Inline Image", "Inline Code", and "Keyboard" toolbar inline formats. Can be re-enabled via `mrw_hidden_block_editor_settings` filter.
-- Hide "Upload" option in "Replace" media menu
-- Remove background color options from Cover block placeholder
-- Hide new Background Image option on Group block
-- Hide new "Text Orientation" / writing mode option
-
-= 2.11.0 (August 21, 2023) =
-- **Requires WordPress 6.0**. Legacy code removed
-- [New] Show all Post- and Query-related blocks in the Site Editor
-- [New] Hide Classic (aka freeform), Details, Footnotes, Comments, and Post Author blocks
-- [New] Hide Group / Cover width settings and Group child blocks Justification settings and min-height setting (does not impact Cover min-height setting). Can be shown with `mrw_hidden_block_editor_settings` filter.
-- [Dev] The `mrw_hidden_blocks` and all `mrw_hidden_*_blocks` filters now support a second `$context` parameter that contains the current screen's ID so you can target the block editor (`post`), site editor (`site-editor`), or widget editor (`widgets`).
-- [New] New Jetpack blocks hidden including AI Assistance, all form blocks, and payment-related blocks
-- [Fix] WordPress 6.3 compatibility (re-hide media upload buttons, default gradients, comments block)
-- [Fix] "getBlockVariations(…) is undefined warning in Widget and Site Editors
-- [Meta] Removed "Formerly MRW Web Design Simple TinyMCE" now that the block editor is 4.5 years old!
-- 2.11.1: Change `layout-width-height` value in the `mrw_hidden_block_editor_settings` filter to be accurate `layout-width`.
-
 = Full Changelog =
 * [Changelog on Github](https://github.com/mrwweb/mrw-simplified-editor-wordpress/blob/master/changelog.txt)
 
 == Upgrade Notice ==
-= 2.14.0 =
-* WordPress 6.9 compatiblity: Hide new blocks. Hide less-used social links.
+= 2.15.0 =
+* WordPress 7.0 compatiblity: Hide new blocks, Font Library, per-block CSS, and more!

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ Visit the GitHub wiki for [examples of filters](https://github.com/mrwweb/mrw-si
     * Fix hiding Fit Text settings for Paragraph and Heading blocks with new settings approach (Editorializing: The way it should have been all along!)
     * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
     * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.
+    * Hide Appearance > Font Library menu item. Show with `font-library` in `mrw_hidden_block_editor_settings`.
 * Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.
 
 = 2.14.0 (November 18, 2025)


### PR DESCRIPTION
* WordPress 7.0 updates
    * Hide New Blocks: Icon, Breadcrumbs (hidden only in post editor) (enable everywhere with the `mrw_hidden_blocks` filter)
    * Hide per-block Custom CSS (enable with `custom-css` value in `mrw_hidden_block_editor_settings`)
    * Hide text indent block setting (enable with `text-indent` value in `mrw_hidden_block_editor_settings`)
    * Fix hiding Fit Text settings for Paragraph and Heading blocks with new settings approach (Editorializing: The way it should have been all along!)
    * Hide new Heading variations for levels 1, 5, 6 to match previous behavior
    * Don't display heading variations in the block inserters. (Editors will continue to insert Heading block and then change level from 2, if necessary.) Show block variations with `heading-variations` in `mrw_hidden_block_editor_settings`.
    * Hide Appearance > Font Library menu item. Show with `font-library` in `mrw_hidden_block_editor_settings`.
    * Fix Save Draft styling to remain looking like a button
	* Fix hiding "Insert from URL" button in image block. (Currently not configurable due to editor iframe)
* Code and comment quality improvements including strict comparison in all filters that use `in_array()` such as `mrw_hidden_blocks`.